### PR TITLE
Add support for CSS Color Module Level 4

### DIFF
--- a/EditorColorPreview.sln
+++ b/EditorColorPreview.sln
@@ -12,6 +12,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		vs-publish.json = vs-publish.json
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EditorColorPreview.Test", "test\EditorColorPreview.Test\EditorColorPreview.Test.csproj", "{198E2552-B2B2-437E-8A9B-16CA9DFDC372}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,6 +30,14 @@ Global
 		{D06E0E89-FA50-4CA2-8799-692039708231}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D06E0E89-FA50-4CA2-8799-692039708231}.Release|x86.ActiveCfg = Release|x86
 		{D06E0E89-FA50-4CA2-8799-692039708231}.Release|x86.Build.0 = Release|x86
+		{198E2552-B2B2-437E-8A9B-16CA9DFDC372}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{198E2552-B2B2-437E-8A9B-16CA9DFDC372}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{198E2552-B2B2-437E-8A9B-16CA9DFDC372}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{198E2552-B2B2-437E-8A9B-16CA9DFDC372}.Debug|x86.Build.0 = Debug|Any CPU
+		{198E2552-B2B2-437E-8A9B-16CA9DFDC372}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{198E2552-B2B2-437E-8A9B-16CA9DFDC372}.Release|Any CPU.Build.0 = Release|Any CPU
+		{198E2552-B2B2-437E-8A9B-16CA9DFDC372}.Release|x86.ActiveCfg = Release|Any CPU
+		{198E2552-B2B2-437E-8A9B-16CA9DFDC372}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [marketplace]: https://marketplace.visualstudio.com/items?itemName=MadsKristensen.ColorPreview
 [vsixgallery]: http://vsixgallery.com/extension/EditorColorPreview.06059b78-ceae-4188-905d-be8877234e35/
-[repo]:https://github.com/madskristensen/EditorColorPreview
+[repo]: https://github.com/madskristensen/EditorColorPreview
 
 # Color Preview for Visual Studio
 
@@ -9,26 +9,74 @@
 Download this extension from the [Visual Studio Marketplace][marketplace]
 or get the [CI build][vsixgallery].
 
---------------------------------------
+---
 
 Shows a color preview in front of all named colors, hex, rgb and hsl values in CSS and JavaScript files.
 
 ![color preview](art/screenshot.png)<br />
-***Figure 1**: Color preview in light theme and dark theme*
+**\*Figure 1**: Color preview in light theme and dark theme\*
 
 ## Supported colors
+
 These color formats are supported:
 
 - Named colors (e.g. `blue`)
 - Hex 3 digits (e.g. `#ff0`)
 - Hex 6 digits (e.g. `#ffff00`)
 - Hex 8 digits (e.g. `#ffff00cc`)
-- RGB (e.g. `rgb(255, 165, 0)`)
-- RGBA (e.g. `rgb(255, 165, 0, 0.5)`)
-- HSL (e.g. `hsl(9, 100%, 64%);`)
-- HSLA (e.g. `hsla(9, 100%, 64%, 0.7);`)
+- RGB
+  - `rgb(255, 165, 0)`
+  - `rgb(0% 50% 0%)`
+  - `rgb(0 128.0 0)`
+  - `rgb(0% 50% 0% / 0.25)` (Alpha channel)
+- RGBA (e.g.
+  - `rgba(255, 165, 0)`
+  - `rgba(0% 50% 0%)`
+  - `rgba(0 128.0 0)`
+  - `rgba(0% 50% 0% / 0.25)`
+- HSL
+  - `hsl(9, 100%, 64%)`
+  - `hsl(120 100% 25%)`
+  - `hsl(120deg 100% 25%)`
+  - `hsl(120 100% 25% / 0.25)`
+  - `hsl(120 none none)`
+- HSLA
+  - `hsla(9, 100%, 64%, 0.7)`
+  - `hsla(120 100% 25%)`
+  - `hsla(120deg 100% 25%)`
+  - `hsla(120 100% 25% / 0.25)`
+  - `hsla(120 none none)`
+- HWB
+  - `hwb(120 0% 49.8039%)`
+  - `hwb(0 0% 100%)`
+  - `hwb(0 100% 100%)`
+  - `hwb(120 30% 50% / 0.5)`
+  - `hwb(none none none)`
+- Lab (Colors are converted to sRGB. Some colors might not convert properly) [^1]
+  - `lab(46.2775% -47.5621 48.5837)`
+  - `lab(100% 0 0)`
+  - `lab(70% -45 0)`
+  - `lab(86.6146% -106.5599 102.8717)`
+- LCH (Colors are converted to sRGB. Some colors might might not convert properly) [^1]
+  - `lch(46.2775% 67.9892 134.3912)`
+  - `lch(0% 0 0)`
+  - `lch(50% 50 0)`
+  - `lch(70% 45 -180)`
+- OKLab (Colors are converted to sRGB. Some colors might not convert properly) [^1]
+  - `oklab(51.975% -0.1403 0.10768)`
+  - `oklab(0% 0 0)`
+  - `oklab(100% 0 0)`
+  - `oklab(50% 0.05 0)`
+- OKLCH (Colors are converted to sRGB. Some colors might not convert properly) [^1]
+  - `oklch(51.975% 0.17686 142.495)`
+  - `oklch(0% 0 0)`
+  - `oklch(100% 0 0)`
+  - `oklch(50% 0.2 0)`
+
+[^1]: A color may be a valid color but still be outside the range of colors that can be produced by an output device (a screen, projector, or printer). It is said to be out of gamut for that color space.
 
 ## How can I help?
+
 If you enjoy using the extension, please give it a ★★★★★ rating on the [Visual Studio Marketplace][marketplace].
 
 Should you encounter bugs or if you have feature requests, head on over to the [GitHub repo][repo] to open an issue if one doesn't already exist.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ These color formats are supported:
   - `lab(100% 0 0)`
   - `lab(70% -45 0)`
   - `lab(86.6146% -106.5599 102.8717)`
-- LCH (Colors are converted to sRGB. Some colors might might not convert properly) [^1]
+- LCH (Colors are converted to sRGB. Some colors might not convert properly) [^1]
   - `lch(46.2775% 67.9892 134.3912)`
   - `lch(0% 0 0)`
   - `lch(50% 50 0)`

--- a/src/Adornments/ColorAdornmentTagger.cs
+++ b/src/Adornments/ColorAdornmentTagger.cs
@@ -22,7 +22,6 @@ namespace EditorColorPreview
 
     internal class ColorAdornmentTagger : ITagger<IntraTextAdornmentTag>, IDisposable
     {
-        public static readonly Regex _regex = new(@"(?<=.*:.*)(#(?:[0-9a-f]{2}){2,4}\b|(#[0-9a-f]{3})\b|\b(rgb|hsl)a?\((-?\d+%?[,\s]+){2,3}\s*[\d\.]+%?\)|(?<=[\s""'])(black|silver|gray|whitesmoke|maroon|red|purple|fuchsia|green|lime|olivedrab|yellow|navy|blue|teal|aquamarine|orange|aliceblue|antiquewhite|aqua|azure|beige|bisque|blanchedalmond|blueviolet|brown|burlywood|cadetblue|chartreuse|chocolate|coral|cornflowerblue|cornsilk|crimson|darkblue|darkcyan|darkgoldenrod|darkgray|darkgreen|darkgrey|darkkhaki|darkmagenta|darkolivegreen|darkorange|darkorchid|darkred|darksalmon|darkseagreen|darkslateblue|darkslategray|darkslategrey|darkturquoise|darkviolet|deeppink|deepskyblue|dimgray|dimgrey|dodgerblue|firebrick|floralwhite|forestgreen|gainsboro|ghostwhite|goldenrod|gold|greenyellow|grey|honeydew|hotpink|indianred|indigo|ivory|khaki|lavenderblush|lavender|lawngreen|lemonchiffon|lightblue|lightcoral|lightcyan|lightgoldenrodyellow|lightgray|lightgreen|lightgrey|lightpink|lightsalmon|lightseagreen|lightskyblue|lightslategray|lightslategrey|lightsteelblue|lightyellow|limegreen|linen|mediumaquamarine|mediumblue|mediumorchid|mediumpurple|mediumseagreen|mediumslateblue|mediumspringgreen|mediumturquoise|mediumvioletred|midnightblue|mintcream|mistyrose|moccasin|navajowhite|oldlace|olive|orangered|orchid|palegoldenrod|palegreen|paleturquoise|palevioletred|papayawhip|peachpuff|peru|pink|plum|powderblue|rosybrown|royalblue|saddlebrown|salmon|sandybrown|seagreen|seashell|sienna|skyblue|slateblue|slategray|slategrey|snow|springgreen|steelblue|tan|thistle|tomato|transparent|turquoise|violet|wheat|white|yellowgreen|rebeccapurple))", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private readonly ITextView _view;
         private readonly ITextBuffer _buffer;
         private bool _isDisposed;
@@ -68,7 +67,7 @@ namespace EditorColorPreview
                 SnapshotSpan currentSpan = span;
                 string text = currentSpan.GetText();
 
-                foreach (Match match in _regex.Matches(text))
+                foreach (Match match in ColorUtils.MatchesColor(text))
                 {
                     Color color = ColorUtils.HtmlToColor(match.Value);
 

--- a/src/Adornments/ColorConvertion.cs
+++ b/src/Adornments/ColorConvertion.cs
@@ -1,0 +1,390 @@
+﻿using System.Linq;
+
+namespace EditorColorPreview
+{
+    public class ColorConvertion
+    {
+        private static double[] _d50 = { 0.3457 / 0.3585, 1.00000, (1.0 - 0.3457 - 0.3585) / 0.3585 };
+        private static double[] _d65 = { 0.3127 / 0.3290, 1.00000, (1.0 - 0.3127 - 0.3290) / 0.3290 };
+
+        // Lab & LCH
+
+        public static double[] LabToRgb(double l, double a, double b)
+        {
+            double[] result = LabToXYZ(new double[] { l, a, b });
+            result = D50ToD65(result);
+            result = XyzToLinearRGB(result);
+            return LinearRgbToRgb(result);
+        }
+
+        public static double[] LchToRgb(double l, double c, double h)
+        {
+            double[] results = LchToLab(new double[] { l, c, h });
+            results = LabToXYZ(results);
+            results = D50ToD65(results);
+            return XyzToLinearRGB(results);
+
+        }
+
+        private static double[] LchToLab(double[] lch) =>
+            new double[] { lch[0], lch[1] * Math.Cos(lch[2]), lch[1] * Math.Sin(lch[2]) };
+
+        private static double[] LabToXYZ(double[] lab)
+        {
+            // Convert Lab to D50-adapted XYZ
+            // http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+            double κ = 24389 / 27;   // 29^3/3^3
+            double ε = 216 / 24389;  // 6^3/29^3
+            double[] f = new double[3];
+
+            // compute f, starting with the luminance-related term
+            f[1] = (lab[0] + 16) / 116;
+            f[0] = lab[1] / 500 + f[1];
+            f[2] = f[1] - lab[2] / 200;
+
+            // compute xyz
+            double[] xyz = {
+                Math.Pow(f[0], 3) > ε ? Math.Pow(f[0], 3) : (116 * f[0] - 16) / κ,
+                lab[0] > κ * ε ? Math.Pow((lab[0] + 16) / 116, 3) : lab[0] / κ,
+                Math.Pow(f[2], 3) > ε ? Math.Pow(f[2], 3) : (116 * f[2] - 16) / κ
+            };
+
+            // Compute XYZ by scaling xyz by reference white
+            return xyz.Select((value, i) => value * _d50[i]).ToArray();
+        }
+
+        // OKLab & OKLCH
+
+        public static double[] OkLabToRgb(double l, double a, double b)
+        {
+            return OkLabToRgb(new double[] { l , a, b });
+        }
+
+        private static double[] OkLabToRgb(double[] okLab)
+        {
+            double[] results = OkLabToXyz(okLab);
+            results = XyzToLinearRGB(results);
+            return LinearRgbToRgb(results);
+        }
+
+        public static double[] OkLchToRgb(double l, double a, double b)
+        {
+            double[] results = OkLchToOkLab(new double[] { l, a, b });
+            return OkLabToRgb(results);
+        }
+
+        private static double[] OkLabToXyz(double[] oKLab)
+        {
+            // Given OKLab, convert to XYZ relative to D65
+            double[,] LMStoXYZ = {
+                { 1.2268798733741557, -0.5578149965554813, 0.28139105017721583 },
+                { -0.04057576262431372, 1.1122868293970594, -0.07171106666151701 },
+                { -0.07637294974672142, -0.4214933239627914, 1.5869240244272418 }
+            };
+            double[,] OKLabtoLMS = {
+                { 0.99999999845051981432, 0.39633779217376785678, 0.21580375806075880339 },
+                { 1.0000000088817607767, -0.1055613423236563494, -0.063854174771705903402 },
+                { 1.0000000546724109177, -0.089484182094965759684, -1.291485537864091739 },
+            };
+
+            double[] LMSnl = MultiplyMatrices(OKLabtoLMS, oKLab);
+            LMSnl = LMSnl.Select(c => Math.Pow(c, 3)).ToArray();
+            return MultiplyMatrices(LMStoXYZ, LMSnl);
+        }
+
+        private static double[] OkLchToOkLab(double[] okLch)
+        {
+            return new double[] {
+                okLch[0], // L is still L
+                okLch[1] * Math.Cos(okLch[2] * Math.PI / 180), // a
+                okLch[1] * Math.Sin(okLch[2] * Math.PI / 180)  // b
+            };
+        }
+
+        // sRGB function
+
+        public static double[] RgbToLinearRgb(double[] rgb)
+        {
+            // convert an array of sRGB values
+            // where in-gamut values are in the range [0 - 1]
+            // to linear light (un-companded) form.
+            // https://en.wikipedia.org/wiki/SRGB
+            // Extended transfer function:
+            // for negative values,  linear portion is extended on reflection of axis,
+            // then reflected power function is used.
+            return rgb.Select(val =>
+            {
+                double sign = val < 0 ? -1 : 1;
+                double abs = Math.Abs(val);
+
+                if (abs < 0.04045)
+                {
+                    return val / 12.92;
+                }
+
+                return sign * (Math.Pow((abs + 0.055) / 1.055, 2.4));
+            }).ToArray();
+        }
+
+        public static double[] LinearRgbToRgb(double[] RGB)
+        {
+            // convert an array of linear-light sRGB values in the range 0.0-1.0
+            // to gamma corrected form
+            // https://en.wikipedia.org/wiki/SRGB
+            // Extended transfer function:
+            // For negative values, linear portion extends on reflection
+            // of axis, then uses reflected pow below that
+            return RGB.Select(v =>
+            {
+                double sign = v < 0 ? -1 : 1;
+                double abs = Math.Abs(v);
+
+                if (abs > 0.0031308)
+                {
+                    return sign * (1.055 * Math.Pow(abs, 1 / 2.4) - 0.055);
+                }
+
+                return 12.92 * v;
+            }).ToArray();
+        }
+
+        private static double[] XyzToLinearRGB(double[] xyz)
+        {
+            // convert XYZ to linear-light sRGB
+
+            double[,] m = {
+                { 3.2409699419045226, -1.537383177570094, -0.4986107602930034 },
+                { -0.9692436362808796, 1.8759675015077202, 0.04155505740717559 },
+                { 0.05563007969699366, -0.20397695888897652, 1.056971514242878 },
+            };
+
+            return MultiplyMatrices(m, xyz);
+        }
+
+        // display-p3-related functions
+
+        public static double[] DisplayP3ToRgb(double n1, double n2, double n3)
+        {
+            double[] results = RgbToLinearRgb(new double[] { n1, n2, n3 });
+            results = LinearP3ToXyz(results);
+            results = XyzToLinearRGB(results);
+            return LinearRgbToRgb(results);
+        }
+
+        private static double[] LinearP3ToXyz(double[] rgb)
+        {
+            // convert an array of linear-light display-p3 values to CIE XYZ
+            // using  D65 (no chromatic adaptation)
+            // http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+            double[,] m = {
+                { 0.4865709486482162, 0.26566769316909306, 0.1982172852343625 },
+                { 0.2289745640697488, 0.6917385218365064, 0.079286914093745 },
+                { 0.0000000000000000, 0.04511338185890264, 1.043944368900976 }
+            };
+            // 0 was computed as -3.972075516933488e-17
+
+            return MultiplyMatrices(m, rgb);
+        }
+
+        // a98-rgb functions
+
+        public static double[] A98RgbToRgb(double n1, double n2, double n3)
+        {
+            double[] results = A98rgbToLinear(new double[] { n1, n2, n3 });
+            results = LinearA98RgbToXyz(results);
+            results = XyzToLinearRGB(results);
+            return LinearRgbToRgb(results);
+        }
+
+        private static double[] A98rgbToLinear(double[] rgb)
+        {
+            // convert an array of a98-rgb values in the range 0.0 - 1.0
+            // to linear light (un-companded) form.
+            // negative values are also now accepted
+            return rgb.Select(val =>
+            {
+                double sign = val < 0 ? -1 : 1;
+                double abs = Math.Abs(val);
+
+                return sign * Math.Pow(abs, 563 / 256);
+            }).ToArray();
+        }
+
+        private static double[] LinearA98RgbToXyz(double[] rgb)
+        {
+            // convert an array of linear-light a98-rgb values to CIE XYZ
+            // http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+            // has greater numerical precision than section 4.3.5.3 of
+            // https://www.adobe.com/digitalimag/pdfs/AdobeRGB1998.pdf
+            // but the values below were calculated from first principles
+            // from the chromaticity coordinates of R G B W
+            // see matrixmaker.html
+            double[,] m = {
+                { 0.5766690429101305, 0.1855582379065463, 0.1882286462349947 },
+                { 0.29734497525053605, 0.6273635662554661, 0.07529145849399788 },
+                { 0.02703136138641234, 0.07068885253582723, 0.9913375368376388 }
+            };
+
+            return MultiplyMatrices(m, rgb);
+        }
+
+        // ProPhoto
+
+        public static double[] ProPhotoToRgb(double n1, double n2, double n3)
+        {
+            double[] results = ProPhotoToLinear(new double[] { n1, n2, n3 });
+            results = LinerProPhotoToXyz(results);
+            results = XyzToLinearRGB(results);
+            results = D50ToD65(results);
+            return LinearRgbToRgb(results);
+        }
+
+        private static double[] ProPhotoToLinear(double[] rgb)
+        {
+            // convert an array of prophoto-rgb values
+            // where in-gamut colors are in the range [0.0 - 1.0]
+            // to linear light (un-companded) form.
+            // Transfer curve is gamma 1.8 with a small linear portion
+            // Extended transfer function
+            double Et2 = 16 / 512;
+            return rgb.Select(v => {
+                double sign = v < 0 ? -1 : 1;
+                double abs = Math.Abs(v);
+
+                if (abs <= Et2)
+                {
+                    return v / 16;
+                }
+
+                return sign * Math.Pow(v, 1.8);
+            }).ToArray();
+        }
+
+        private static double[] LinerProPhotoToXyz(double[] rgb)
+        {
+            // convert an array of linear-light prophoto-rgb values to CIE XYZ
+            // using  D50 (so no chromatic adaptation needed afterwards)
+            // http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+            double[,] m = {
+                { 0.7977604896723027, 0.13518583717574031, 0.0313493495815248 },
+                { 0.2880711282292934, 0.7118432178101014, 0.00008565396060525902 },
+                { 0.0, 0.0, 0.8251046025104601 }
+	        };
+
+            return MultiplyMatrices(m, rgb);
+        }
+
+        // Rec. 2020
+
+        public static double[] Rec2020ToRgb(double n1, double n2, double n3)
+        {
+            double[] results = Rec2020ToLinear(new double[] { n1, n2, n3 });
+            results = LinearRec2020ToXyz(results);
+            results = XyzToLinearRGB(results);
+            return LinearRgbToRgb(results);
+        }
+
+        private static double[] Rec2020ToLinear(double[] rgb)
+        {
+            // convert an array of rec2020 RGB values in the range 0.0 - 1.0
+            // to linear light (un-companded) form.
+            // ITU-R BT.2020-2 p.4
+
+            double α = 1.09929682680944;
+            double β = 0.018053968510807;
+
+            return rgb.Select(val =>
+            {
+                double sign = val < 0 ? -1 : 1;
+                double abs = Math.Abs(val);
+
+                if (abs < β * 4.5)
+                {
+                    return val / 4.5;
+                }
+
+                return sign * (Math.Pow((abs + α - 1) / α, 1 / 0.45));
+            }).ToArray();
+        }
+
+        private static double[] LinearRec2020ToXyz(double[] rgb)
+        {
+            // convert an array of linear-light rec2020 values to CIE XYZ
+            // using  D65 (no chromatic adaptation)
+            // http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+            double[,] m = {
+                { 0.6369580483012914, 0.14461690358620832, 0.1688809751641721 },
+                { 0.2627002120112671, 0.6779980715188708, 0.05930171646986196 },
+                { 0.000000000000000, 0.028072693049087428, 1.060985057710791 }
+	        };
+            // 0 is actually calculated as  4.994106574466076e-17
+
+            return MultiplyMatrices(m, rgb);
+        }
+
+        // XYZ
+
+        public static double[] XyzToRgb(double n1, double n2, double n3, bool covertWhitePoint = false)
+        {
+            double[] results;
+            if (covertWhitePoint)
+            {
+                results = D50ToD65(new double[] { n1, n2, n3 });
+                results = XyzToLinearRGB(results);
+            }
+            else
+            {
+                results = XyzToLinearRGB(new double[] { n1, n2, n3 });
+            }
+
+            return LinearRgbToRgb(results);
+        }
+
+
+        public double[] D65ToD50(double[] xyz)
+        {
+            // Bradford chromatic adaptation from D65 to D50
+            // The matrix below is the result of three operations:
+            // - convert from XYZ to retinal cone domain
+            // - scale components from one reference white to another
+            // - convert back to XYZ
+            // http://www.brucelindbloom.com/index.html?Eqn_ChromAdapt.html
+            double[,] m = {
+                { 1.0479298208405488, 0.022946793341019088, -0.05019222954313557 },
+                { 0.029627815688159344, 0.990434484573249, -0.01707382502938514 },
+                { -0.009243058152591178, 0.015055144896577895, 0.7518742899580008 }
+            };
+
+            return MultiplyMatrices(m, xyz);
+        }
+
+        private static double[] D50ToD65(double[] xyz)
+        {
+            // Bradford chromatic adaptation from D50 to D65
+            double[,] M = {
+                { 0.9554734527042182, -0.023098536874261423, 0.0632593086610217 },
+                { -0.028369706963208136, 1.0099954580058226, 0.021041398966943008 },
+                {  0.012314001688319899, -0.020507696433477912, 1.3303659366080753 }
+            };
+
+            return MultiplyMatrices(M, xyz);
+        }
+
+        // Matrix Math
+
+        private static double[] MultiplyMatrices(double[,] m, double[] vector)
+        {
+            double c1 = m[0, 0] * vector[0]
+                + m[0, 1] * vector[1]
+                + m[0, 2] * vector[2];
+            double c2 = m[1, 0] * vector[0]
+                + m[1, 1] * vector[1]
+                + m[1, 2] * vector[2];
+            double c3 = m[2, 0] * vector[0]
+                + m[2, 1] * vector[1]
+                + m[2, 2] * vector[2];
+
+            return new double[] { c1, c2, c3 };
+        }
+    }
+}

--- a/src/Adornments/ColorUtils.cs
+++ b/src/Adornments/ColorUtils.cs
@@ -1,271 +1,381 @@
 ﻿using System.Drawing;
-using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 
-// From https://stackoverflow.com/a/61871235
-public static class ColorUtils
+
+namespace EditorColorPreview
 {
-    public static readonly Regex _regex = new(@"(?<=.*:.*)(#(?:[0-9a-f]{2}){2,4}\b|(#[0-9a-f]{3})\b|\b(rgb|hsl|hwb)a?\(((\d+(%|deg)?|none)(,|,\s*|\s*)){2}(\d+(%|deg)?|none){1}\s*[\/\d\.]*%?\s*([\d\.]*)*\)|(?<=[\s""'])(black|silver|gray|whitesmoke|maroon|red|purple|fuchsia|green|lime|olivedrab|yellow|navy|blue|teal|aquamarine|orange|aliceblue|antiquewhite|aqua|azure|beige|bisque|blanchedalmond|blueviolet|brown|burlywood|cadetblue|chartreuse|chocolate|coral|cornflowerblue|cornsilk|crimson|darkblue|darkcyan|darkgoldenrod|darkgray|darkgreen|darkgrey|darkkhaki|darkmagenta|darkolivegreen|darkorange|darkorchid|darkred|darksalmon|darkseagreen|darkslateblue|darkslategray|darkslategrey|darkturquoise|darkviolet|deeppink|deepskyblue|dimgray|dimgrey|dodgerblue|firebrick|floralwhite|forestgreen|gainsboro|ghostwhite|goldenrod|gold|greenyellow|grey|honeydew|hotpink|indianred|indigo|ivory|khaki|lavenderblush|lavender|lawngreen|lemonchiffon|lightblue|lightcoral|lightcyan|lightgoldenrodyellow|lightgray|lightgreen|lightgrey|lightpink|lightsalmon|lightseagreen|lightskyblue|lightslategray|lightslategrey|lightsteelblue|lightyellow|limegreen|linen|mediumaquamarine|mediumblue|mediumorchid|mediumpurple|mediumseagreen|mediumslateblue|mediumspringgreen|mediumturquoise|mediumvioletred|midnightblue|mintcream|mistyrose|moccasin|navajowhite|oldlace|olive|orangered|orchid|palegoldenrod|palegreen|paleturquoise|palevioletred|papayawhip|peachpuff|peru|pink|plum|powderblue|rosybrown|royalblue|saddlebrown|salmon|sandybrown|seagreen|seashell|sienna|skyblue|slateblue|slategray|slategrey|snow|springgreen|steelblue|tan|thistle|tomato|transparent|turquoise|violet|wheat|white|yellowgreen|rebeccapurple))", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-    public static Color HtmlToColor(string htmlColor)
+    public static class ColorUtils
     {
-        try
+          public static readonly Regex _regex = new(@"(?<=.*:.*)(#(?:[0-9a-f]{2}){2,4}\b|(#[0-9a-f]{3})\b|\b(color|rgb|hsl|hwb|lab|lch|oklab|oklch)a?\(((srgb|srgb-linear|display-p3|a98-rgb|photo-rgb|rec2020|xyz-d50|xyz-d65|xyz)\s*)?((-?(\d*\.)?\d+(%|deg)?|none)(,|,\s*|\s*)){2}(-?(\d*\.)?\d+(%|deg)?|none){1}\s*[\/\d\.]*%?\s*([\d\.]*)*\)|(?<=[\s""'])(black|silver|gray|whitesmoke|maroon|red|purple|fuchsia|green|lime|olivedrab|yellow|navy|blue|teal|aquamarine|orange|aliceblue|antiquewhite|aqua|azure|beige|bisque|blanchedalmond|blueviolet|brown|burlywood|cadetblue|chartreuse|chocolate|coral|cornflowerblue|cornsilk|crimson|darkblue|darkcyan|darkgoldenrod|darkgray|darkgreen|darkgrey|darkkhaki|darkmagenta|darkolivegreen|darkorange|darkorchid|darkred|darksalmon|darkseagreen|darkslateblue|darkslategray|darkslategrey|darkturquoise|darkviolet|deeppink|deepskyblue|dimgray|dimgrey|dodgerblue|firebrick|floralwhite|forestgreen|gainsboro|ghostwhite|goldenrod|gold|greenyellow|grey|honeydew|hotpink|indianred|indigo|ivory|khaki|lavenderblush|lavender|lawngreen|lemonchiffon|lightblue|lightcoral|lightcyan|lightgoldenrodyellow|lightgray|lightgreen|lightgrey|lightpink|lightsalmon|lightseagreen|lightskyblue|lightslategray|lightslategrey|lightsteelblue|lightyellow|limegreen|linen|mediumaquamarine|mediumblue|mediumorchid|mediumpurple|mediumseagreen|mediumslateblue|mediumspringgreen|mediumturquoise|mediumvioletred|midnightblue|mintcream|mistyrose|moccasin|navajowhite|oldlace|olive|orangered|orchid|palegoldenrod|palegreen|paleturquoise|palevioletred|papayawhip|peachpuff|peru|pink|plum|powderblue|rosybrown|royalblue|saddlebrown|salmon|sandybrown|seagreen|seashell|sienna|skyblue|slateblue|slategray|slategrey|snow|springgreen|steelblue|tan|thistle|tomato|transparent|turquoise|violet|wheat|white|yellowgreen|rebeccapurple))", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        public static Color HtmlToColor(string htmlColor)
         {
-            // RGB
-            if (htmlColor.StartsWith("rgb", StringComparison.OrdinalIgnoreCase))
+            try
             {
-                return ArgbToColor(htmlColor);
-            }
+                // RGB
+                if (htmlColor.StartsWith("rgb", StringComparison.OrdinalIgnoreCase))
+                {
+                    return ArgbToColor(htmlColor);
+                }
 
-            // HSL
-            if (htmlColor.StartsWith("hsl", StringComparison.OrdinalIgnoreCase))
+                // HSL
+                if (htmlColor.StartsWith("hsl", StringComparison.OrdinalIgnoreCase))
+                {
+                    return HslToColor(htmlColor);
+                }
+
+                // HWB
+                if (htmlColor.StartsWith("hwb", StringComparison.OrdinalIgnoreCase))
+                {
+                    return HwbToColor(htmlColor);
+                }
+
+                // LAB
+                if (htmlColor.StartsWith("lab", StringComparison.OrdinalIgnoreCase))
+                {
+                    return LabToColor(htmlColor);
+                }
+
+                // LCH
+                if (htmlColor.StartsWith("lch", StringComparison.OrdinalIgnoreCase))
+                {
+                    return LchToColor(htmlColor);
+                }
+
+                // OKLAB
+                if (htmlColor.StartsWith("oklab", StringComparison.OrdinalIgnoreCase))
+                {
+                    return OkLabToColor(htmlColor);
+                }
+
+                // OKLCH
+                if (htmlColor.StartsWith("oklch", StringComparison.OrdinalIgnoreCase))
+                {
+                    return OkLchToColor(htmlColor);
+                }
+
+                // Color
+                if (htmlColor.StartsWith("color", StringComparison.OrdinalIgnoreCase))
+                {
+                    return ColorToColor(htmlColor);
+                }
+
+                // HEX
+                if (htmlColor.StartsWith("#", StringComparison.Ordinal))
+                {
+                    return HexToColor(htmlColor);
+                }
+
+                // Named colors
+                if (htmlColor.Equals("rebeccapurple", StringComparison.OrdinalIgnoreCase))
+                {
+                    htmlColor = "#663399";
+                }
+
+                return ColorTranslator.FromHtml(htmlColor);
+
+            }
+            catch
             {
-                return HslToColor(htmlColor);
+                return Color.Empty;
             }
-
-            // HWB
-            if (htmlColor.StartsWith("hwb", StringComparison.OrdinalIgnoreCase))
-            {
-                return HwbToColor(htmlColor);
-            }
-
-            // HEX
-            if (htmlColor.StartsWith("#", StringComparison.Ordinal))
-            {
-                return HexToColor(htmlColor);
-            }
-
-            // Named colors
-            if (htmlColor.Equals("rebeccapurple", StringComparison.OrdinalIgnoreCase))
-            {
-                htmlColor = "#663399";
-            }
-
-            return ColorTranslator.FromHtml(htmlColor);
-
         }
-        catch
+
+        public static MatchCollection MatchesColor(string html)
         {
+            return _regex.Matches(html);
+        }
+
+        private static Color HexToColor(string htmlColor)
+        {
+            int len = htmlColor.Length;
+
+            // #RGB
+            if (len == 4)
+            {
+                int r = Convert.ToInt32(htmlColor.Substring(1, 1), 16);
+                int g = Convert.ToInt32(htmlColor.Substring(2, 1), 16);
+                int b = Convert.ToInt32(htmlColor.Substring(3, 1), 16);
+
+                return Color.FromArgb(r + (r * 16), g + (g * 16), b + (b * 16));
+            }
+
+            // #RGBA
+            else if (len == 5)
+            {
+                int r = Convert.ToInt32(htmlColor.Substring(1, 1), 16);
+                int g = Convert.ToInt32(htmlColor.Substring(2, 1), 16);
+                int b = Convert.ToInt32(htmlColor.Substring(3, 1), 16);
+                int a = Convert.ToInt32(htmlColor.Substring(4, 1), 16);
+
+                return Color.FromArgb(a + (a * 16), r + (r * 16), g + (g * 16), b + (b * 16));
+            }
+
+            // #RRGGBB
+            else if (len == 7)
+            {
+                return Color.FromArgb(
+                    Convert.ToInt32(htmlColor.Substring(1, 2), 16),
+                    Convert.ToInt32(htmlColor.Substring(3, 2), 16),
+                    Convert.ToInt32(htmlColor.Substring(5, 2), 16));
+            }
+
+            // #RRGGBBAA
+            else if (len == 9)
+            {
+                return Color.FromArgb(
+                    Convert.ToInt32(htmlColor.Substring(7, 2), 16),
+                    Convert.ToInt32(htmlColor.Substring(1, 2), 16),
+                    Convert.ToInt32(htmlColor.Substring(3, 2), 16),
+                    Convert.ToInt32(htmlColor.Substring(5, 2), 16));
+            }
+
             return Color.Empty;
         }
-    }
 
-    public static MatchCollection MatchesColor(string html)
-    {
-        return _regex.Matches(html);
-    }
-
-    private static Color HexToColor(string htmlColor)
-    {
-        int len = htmlColor.Length;
-
-        // #RGB
-        if (len == 4)
+        private static Color ArgbToColor(string htmlColor)
         {
-            int r = Convert.ToInt32(htmlColor.Substring(1, 1), 16);
-            int g = Convert.ToInt32(htmlColor.Substring(2, 1), 16);
-            int b = Convert.ToInt32(htmlColor.Substring(3, 1), 16);
+            string[] parts = ColorParts(htmlColor);
 
-            return Color.FromArgb(r + (r * 16), g + (g * 16), b + (b * 16));
+            double r = GetNumberOrPercentage(parts[0]);
+            double g = GetNumberOrPercentage(parts[1]);
+            double b = GetNumberOrPercentage(parts[2]);
+
+            double a = parts.Length > 3 ? GetNumberOrPercentage(parts[3]) : 1.0;
+
+            if (parts[0].Contains('%') || parts[1].Contains('%') || parts[2].Contains('%'))
+            {
+                return FromArgb(a, r, g, b);
+            }
+            else
+            {
+                return FromArgb(a, (int)r, (int)g, (int)b);
+            }
         }
 
-        // #RGBA
-        else if (len == 5)
+        private static Color HslToColor(string htmlColor)
         {
-            int r = Convert.ToInt32(htmlColor.Substring(1, 1), 16);
-            int g = Convert.ToInt32(htmlColor.Substring(2, 1), 16);
-            int b = Convert.ToInt32(htmlColor.Substring(3, 1), 16);
-            int a = Convert.ToInt32(htmlColor.Substring(4, 1), 16);
+            string[] parts = ColorParts(htmlColor);
 
-            return Color.FromArgb(a + (a * 16), r + (r * 16), g + (g * 16), b + (b * 16));
-        }
+            double h = GetNumberOrPercentage(parts[0]);
+            double s = GetNumberOrPercentage(parts[1]);
+            double l = GetNumberOrPercentage(parts[2]);
+            double a = parts.Length > 3 ? GetNumberOrPercentage(parts[3]) : 1.0;
 
-        // #RRGGBB
-        else if (len == 7)
-        {
-            return Color.FromArgb(
-                Convert.ToInt32(htmlColor.Substring(1, 2), 16),
-                Convert.ToInt32(htmlColor.Substring(3, 2), 16),
-                Convert.ToInt32(htmlColor.Substring(5, 2), 16));
-        }
-
-        // #RRGGBBAA
-        else if (len == 9)
-        {
-            return Color.FromArgb(
-                Convert.ToInt32(htmlColor.Substring(7, 2), 16),
-                Convert.ToInt32(htmlColor.Substring(1, 2), 16),
-                Convert.ToInt32(htmlColor.Substring(3, 2), 16),
-                Convert.ToInt32(htmlColor.Substring(5, 2), 16));
-        }
-
-        return Color.Empty;
-    }
-
-    private static Color ArgbToColor(string htmlColor)
-    {
-        string[] parts = ColorParts(htmlColor);
-
-        double r = GetNumberOrPercentage(parts[0]);
-        double g = GetNumberOrPercentage(parts[1]);
-        double b = GetNumberOrPercentage(parts[2]);
-
-        double a = parts.Length > 3 ? GetNumberOrPercentage(parts[3]) : 1.0;
-
-        if (parts[0].Contains('%') || parts[1].Contains('%') || parts[2].Contains('%'))
-        {
-            return FromArgb(a, r, g, b);
-        }
-        else
-        {
-            return FromArgb(a, (int)r, (int)g, (int)b);
-        }
-    }
-
-    private static Color HslToColor(string htmlColor)
-    {
-        string[] parts = ColorParts(htmlColor);
-
-        double h = GetNumberOrPercentage(parts[0]);
-        double s = GetNumberOrPercentage(parts[1]);
-        double l = GetNumberOrPercentage(parts[2]);
-
-        double[] rgb = HslToRgb(h, s, l);
-
-        if (parts.Length == 3)
-        {
-            return FromArgb(rgb[0], rgb[1], rgb[2]);
-        }
-        else if (parts.Length == 4)
-        {
-            float a = float.Parse(parts[3], CultureInfo.InvariantCulture);
+            double[] rgb = HslToRgb(h, s, l);
 
             return FromArgb(a, rgb[0], rgb[1], rgb[2]);
         }
 
-        return Color.Empty;
-    }
-
-    private static Color HwbToColor(string htmlColor)
-    {
-        string[] parts = ColorParts(htmlColor);
-
-        double hue = GetNumberOrPercentage(parts[0]);
-        double white = GetNumberOrPercentage(parts[1]);
-        double black = GetNumberOrPercentage(parts[2]);
-        
-        double a = parts.Length > 3 ? GetNumberOrPercentage(parts[3]) : 1.0;
-
-        if (white + black >= 1)
+        private static Color HwbToColor(string htmlColor)
         {
-            double gray = white / (white + black);
-            return FromArgb(a, gray, gray, gray);
-        }
+            string[] parts = ColorParts(htmlColor);
 
-        double[] rgb = HslToRgb(hue, 1, .5);
-        float[] rgb2 = HslToRgb(hue, 1, .5).Select(v => (float)v).ToArray();
+            double hue = GetNumberOrPercentage(parts[0]);
+            double white = GetNumberOrPercentage(parts[1]);
+            double black = GetNumberOrPercentage(parts[2]);
 
-        for (int i = 0; i < 3; i++)
-        {
-            rgb[i] *= Math.Round((1 - white - black), 2);
-            rgb[i] += white;
-        }
+            double a = parts.Length > 3 ? GetNumberOrPercentage(parts[3]) : 1.0;
 
-        return FromArgb(a, rgb[0], rgb[1], rgb[2]);
-    }
-
-    private static double[] HslToRgb(double hue, double sat, double light)
-    {
-        hue %= 360.0;
-
-        if (hue < 0)
-        {
-            hue += 360;
-        }
-
-        double f(double n)
-        {
-            double k = (n + hue / 30.0) % 12.0;
-            double a = sat * Math.Min(light, 1 - light);
-            return light - a * Math.Max(-1, Math.Min(Math.Min(k - 3.0, 9.0 - k), 1));
-        };
-
-        return new double[] { f(0), f(8), f(4) };
-    }
-
-    private static string[] ColorParts(string htmlColor)
-    {
-        int left = htmlColor.IndexOf('(');
-        int right = htmlColor.IndexOf(')');
-
-        if (left < 0 || right < 0)
-        {
-            return new string[] { };
-        }
-
-        string noBrackets = htmlColor.Substring(left + 1, right - left - 1).Replace("deg", "");
-
-        char seperator = htmlColor.Contains(',') ? ',' : ' ';
-
-        string[] parts;
-        string[] alphaChannel = noBrackets.Split('/');
-        if (alphaChannel.Length == 2)
-        {
-            parts = alphaChannel[0].Trim().Split(seperator).Append(alphaChannel[1]).ToArray();
-        }
-        else
-        {
-            parts = alphaChannel[0].Split(seperator);
-        }
-
-        return parts.Select(p => p.Trim() == "none" ? "0" : p.Trim()).ToArray(); ;
-    }
-
-    private static double GetNumberOrPercentage(string part)
-    {
-        string raw = part.TrimEnd('%');
-
-        if (double.TryParse(raw, out double d))
-        {
-            if (part.Contains('%') && d > 1)
+            if (white + black >= 1)
             {
-                return d / 100.0;
+                double gray = white / (white + black);
+                return FromArgb(a, gray, gray, gray);
             }
+
+            double[] rgb = HslToRgb(hue, 1, .5);
+
+            for (int i = 0; i < 3; i++)
+            {
+                rgb[i] *= Math.Round((1 - white - black), 2);
+                rgb[i] += white;
+            }
+
+            return FromArgb(a, rgb[0], rgb[1], rgb[2]);
         }
 
-        return d;
-    }
+        private static Color LabToColor(string htmlColor)
+        {
+            string[] parts = ColorParts(htmlColor);
 
-    public static Color FromArgb(double a, int r, int g, int b)
-    {
-        a = Math.Round(ClampAlpha(a) * 255.0, MidpointRounding.AwayFromZero);
-        return Color.FromArgb((int)a, ClampRgb(r), ClampRgb(g), ClampRgb(b));
-    }
+            double l = GetNumberOrPercentage(parts[0]);
+            double a = GetNumberOrPercentage(parts[1]);
+            double b = GetNumberOrPercentage(parts[2]);
 
-    public static Color FromArgb(double r, double g, double b)
-    {
-        return FromArgb(1.0, r, g, b);
-    }
+            double[] rgb = ColorConvertion.LabToRgb(l * 100, a, b);
 
-    public static Color FromArgb(double a, double r, double g, double b)
-    {
-        a = Math.Round(ClampAlpha(a) * 255.0, MidpointRounding.AwayFromZero);
-        r = Math.Round(r * 255.0, MidpointRounding.AwayFromZero);
-        g = Math.Round(g * 255.0, MidpointRounding.AwayFromZero);
-        b = Math.Round(b * 255.0, MidpointRounding.AwayFromZero);
-        return Color.FromArgb(ClampRgb((int)a), ClampRgb((int)r), ClampRgb((int)g), ClampRgb((int)b));
-    }
+            return FromArgb(1, rgb[0], rgb[1], rgb[2]);
+        }
 
-    public static int ClampRgb(int value)
-    {
-        return value < 0 ? 0 : value > 255 ? 255 : value;
-        
-    }
+        private static Color LchToColor(string htmlColor)
+        {
+            string[] parts = ColorParts(htmlColor);
 
-    public static double ClampAlpha(double value)
-    {
-        return value < 0.0 ? 0.0 : value > 1.0 ? 1.0 : value;
+            double l = GetNumberOrPercentage(parts[0]);
+            double c = GetNumberOrPercentage(parts[1]);
+            double h = GetNumberOrPercentage(parts[2]);
 
+            double[] rgb = ColorConvertion.LchToRgb(l * 100, c, h);
+
+            return FromArgb(rgb[0], rgb[1], rgb[2]);
+        }
+
+        private static Color OkLabToColor(string htmlColor)
+        {
+            string[] parts = ColorParts(htmlColor);
+
+            double l = GetNumberOrPercentage(parts[0]);
+            double a = GetNumberOrPercentage(parts[1]);
+            double b = GetNumberOrPercentage(parts[2]);
+
+            double[] rgb = ColorConvertion.OkLabToRgb(l, a, b);
+
+            return FromArgb(1, rgb[0], rgb[1], rgb[2]);
+        }
+
+        private static Color OkLchToColor(string htmlColor)
+        {
+            string[] parts = ColorParts(htmlColor);
+
+            double l = GetNumberOrPercentage(parts[0]);
+            double c = GetNumberOrPercentage(parts[1]);
+            double h = GetNumberOrPercentage(parts[2]);
+
+            double[] rgb = ColorConvertion.OkLchToRgb(l, c, h);
+
+            return FromArgb(rgb[0], rgb[1], rgb[2]);
+        }
+
+        private static Color ColorToColor(string htmlColors)
+        {
+            string[] parts = ColorParts(htmlColors);
+
+            double n1 = parts[0].ToUpper().StartsWith("XYZ") ?
+                GetNumberOrPercentage(parts[1]) :
+                ClampZeroToOne(GetNumberOrPercentage(parts[1]));
+            double n2 = parts[0].ToUpper().StartsWith("XYZ") ?
+                GetNumberOrPercentage(parts[2]) :
+                ClampZeroToOne(GetNumberOrPercentage(parts[2]));
+            double n3 = parts[0].ToUpper().StartsWith("XYZ") ?
+                GetNumberOrPercentage(parts[3]) :
+                ClampZeroToOne(GetNumberOrPercentage(parts[3]));
+
+            double a = parts.Length == 5 ? GetNumberOrPercentage(parts[4]) : 1;
+
+            if (parts[0].Equals("SRGB", StringComparison.OrdinalIgnoreCase))
+            {
+                return FromArgb(a, n1, n2, n3);
+            }
+
+            double[] rgb = parts[0].ToUpper() switch
+            {
+                "SRGB-LINEAR" => ColorConvertion.LinearRgbToRgb(new double[] { n1, n2, n3 }),
+                "DISPLAY-P3" => ColorConvertion.DisplayP3ToRgb(n1, n2, n3),
+                "A98-RGB" => ColorConvertion.A98RgbToRgb(n1, n2, n3),
+                "PROPHOTO-RGB" => ColorConvertion.ProPhotoToRgb(n1, n2, n3),
+                "REC2020" => ColorConvertion.Rec2020ToRgb(n1, n2, n3),
+                "XYZ" or "XYZ-D65" => ColorConvertion.XyzToRgb(n1, n2, n3),
+                "XYZ-D50" => ColorConvertion.XyzToRgb(n1, n2, n3, true),
+                _ => new double[] { 0, 0, 0 },
+            };
+
+            return FromArgb(a, rgb[0], rgb[1], rgb[2]);
+        }
+
+        private static double[] HslToRgb(double hue, double sat, double light)
+        {
+            hue %= 360.0;
+
+            if (hue < 0)
+            {
+                hue += 360;
+            }
+
+            double f(double n)
+            {
+                double k = (n + hue / 30.0) % 12.0;
+                double a = sat * Math.Min(light, 1 - light);
+                return light - a * Math.Max(-1, Math.Min(Math.Min(k - 3.0, 9.0 - k), 1));
+            };
+
+            return new double[] { f(0), f(8), f(4) };
+        }
+
+        private static string[] ColorParts(string htmlColor)
+        {
+            int left = htmlColor.IndexOf('(');
+            int right = htmlColor.IndexOf(')');
+
+            if (left < 0 || right < 0)
+            {
+                return new string[] { };
+            }
+
+            string noBrackets = htmlColor.Substring(left + 1, right - left - 1).Replace("deg", "");
+
+            char seperator = htmlColor.Contains(',') ? ',' : ' ';
+
+            string[] parts;
+            string[] alphaChannel = noBrackets.Split('/');
+            if (alphaChannel.Length == 2)
+            {
+                parts = alphaChannel[0].Trim().Split(new char[] { seperator }, StringSplitOptions.RemoveEmptyEntries).Append(alphaChannel[1]).ToArray();
+            }
+            else
+            {
+                parts = alphaChannel[0].Split(new char[] { seperator }, StringSplitOptions.RemoveEmptyEntries);
+            }
+
+            return parts.Select(p => p.Trim().Equals("none") ? "0" : p.Trim()).ToArray(); ;
+        }
+
+        private static double GetNumberOrPercentage(string part)
+        {
+            string raw = part.TrimEnd('%');
+
+            if (double.TryParse(raw, out double d))
+            {
+                if (part.Contains('%') && d > 1)
+                {
+                    return d / 100.0;
+                }
+            }
+
+            return d;
+        }
+
+        public static Color FromArgb(double a, int r, int g, int b)
+        {
+            a = Math.Round(ClampZeroToOne(a) * 255.0, MidpointRounding.AwayFromZero);
+            return Color.FromArgb((int)a, ClampRgb(r), ClampRgb(g), ClampRgb(b));
+        }
+
+        public static Color FromArgb(double r, double g, double b)
+        {
+            return FromArgb(1.0, r, g, b);
+        }
+
+        public static Color FromArgb(double a, double r, double g, double b)
+        {
+            a = Math.Round(ClampZeroToOne(a) * 255.0, MidpointRounding.AwayFromZero);
+            r = Math.Round(r * 255.0, MidpointRounding.AwayFromZero);
+            g = Math.Round(g * 255.0, MidpointRounding.AwayFromZero);
+            b = Math.Round(b * 255.0, MidpointRounding.AwayFromZero);
+            return Color.FromArgb(ClampRgb((int)a), ClampRgb((int)r), ClampRgb((int)g), ClampRgb((int)b));
+        }
+
+        public static int ClampRgb(int value)
+        {
+            return value < 0 ? 0 : value > 255 ? 255 : value;
+
+        }
+
+        public static double ClampZeroToOne(double value)
+        {
+            return value < 0.0 ? 0.0 : value > 1.0 ? 1.0 : value;
+
+        }
     }
 }

--- a/src/Adornments/ColorUtils.cs
+++ b/src/Adornments/ColorUtils.cs
@@ -1,10 +1,13 @@
 ﻿using System.Drawing;
 using System.Globalization;
-using Microsoft.VisualStudio.Imaging;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 // From https://stackoverflow.com/a/61871235
 public static class ColorUtils
 {
+    public static readonly Regex _regex = new(@"(?<=.*:.*)(#(?:[0-9a-f]{2}){2,4}\b|(#[0-9a-f]{3})\b|\b(rgb|hsl|hwb)a?\(((\d+(%|deg)?|none)(,|,\s*|\s*)){2}(\d+(%|deg)?|none){1}\s*[\/\d\.]*%?\s*([\d\.]*)*\)|(?<=[\s""'])(black|silver|gray|whitesmoke|maroon|red|purple|fuchsia|green|lime|olivedrab|yellow|navy|blue|teal|aquamarine|orange|aliceblue|antiquewhite|aqua|azure|beige|bisque|blanchedalmond|blueviolet|brown|burlywood|cadetblue|chartreuse|chocolate|coral|cornflowerblue|cornsilk|crimson|darkblue|darkcyan|darkgoldenrod|darkgray|darkgreen|darkgrey|darkkhaki|darkmagenta|darkolivegreen|darkorange|darkorchid|darkred|darksalmon|darkseagreen|darkslateblue|darkslategray|darkslategrey|darkturquoise|darkviolet|deeppink|deepskyblue|dimgray|dimgrey|dodgerblue|firebrick|floralwhite|forestgreen|gainsboro|ghostwhite|goldenrod|gold|greenyellow|grey|honeydew|hotpink|indianred|indigo|ivory|khaki|lavenderblush|lavender|lawngreen|lemonchiffon|lightblue|lightcoral|lightcyan|lightgoldenrodyellow|lightgray|lightgreen|lightgrey|lightpink|lightsalmon|lightseagreen|lightskyblue|lightslategray|lightslategrey|lightsteelblue|lightyellow|limegreen|linen|mediumaquamarine|mediumblue|mediumorchid|mediumpurple|mediumseagreen|mediumslateblue|mediumspringgreen|mediumturquoise|mediumvioletred|midnightblue|mintcream|mistyrose|moccasin|navajowhite|oldlace|olive|orangered|orchid|palegoldenrod|palegreen|paleturquoise|palevioletred|papayawhip|peachpuff|peru|pink|plum|powderblue|rosybrown|royalblue|saddlebrown|salmon|sandybrown|seagreen|seashell|sienna|skyblue|slateblue|slategray|slategrey|snow|springgreen|steelblue|tan|thistle|tomato|transparent|turquoise|violet|wheat|white|yellowgreen|rebeccapurple))", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
     public static Color HtmlToColor(string htmlColor)
     {
         try
@@ -19,6 +22,12 @@ public static class ColorUtils
             if (htmlColor.StartsWith("hsl", StringComparison.OrdinalIgnoreCase))
             {
                 return HslToColor(htmlColor);
+            }
+
+            // HWB
+            if (htmlColor.StartsWith("hwb", StringComparison.OrdinalIgnoreCase))
+            {
+                return HwbToColor(htmlColor);
             }
 
             // HEX
@@ -40,6 +49,11 @@ public static class ColorUtils
         {
             return Color.Empty;
         }
+    }
+
+    public static MatchCollection MatchesColor(string html)
+    {
+        return _regex.Matches(html);
     }
 
     private static Color HexToColor(string htmlColor)
@@ -91,77 +105,167 @@ public static class ColorUtils
 
     private static Color ArgbToColor(string htmlColor)
     {
-        int left = htmlColor.IndexOf('(');
-        int right = htmlColor.IndexOf(')');
+        string[] parts = ColorParts(htmlColor);
 
-        if (left < 0 || right < 0)
+        double r = GetNumberOrPercentage(parts[0]);
+        double g = GetNumberOrPercentage(parts[1]);
+        double b = GetNumberOrPercentage(parts[2]);
+
+        double a = parts.Length > 3 ? GetNumberOrPercentage(parts[3]) : 1.0;
+
+        if (parts[0].Contains('%') || parts[1].Contains('%') || parts[2].Contains('%'))
         {
-            return Color.Empty;
+            return FromArgb(a, r, g, b);
         }
+        else
+        {
+            return FromArgb(a, (int)r, (int)g, (int)b);
+        }
+    }
 
-        string noBrackets = htmlColor.Substring(left + 1, right - left - 1);
+    private static Color HslToColor(string htmlColor)
+    {
+        string[] parts = ColorParts(htmlColor);
 
-        string[] parts = noBrackets.Split(',');
+        double h = GetNumberOrPercentage(parts[0]);
+        double s = GetNumberOrPercentage(parts[1]);
+        double l = GetNumberOrPercentage(parts[2]);
 
-        int r = int.Parse(parts[0], CultureInfo.InvariantCulture);
-        int g = int.Parse(parts[1], CultureInfo.InvariantCulture);
-        int b = int.Parse(parts[2], CultureInfo.InvariantCulture);
+        double[] rgb = HslToRgb(h, s, l);
 
         if (parts.Length == 3)
         {
-            return Color.FromArgb(r, g, b);
+            return FromArgb(rgb[0], rgb[1], rgb[2]);
         }
         else if (parts.Length == 4)
         {
             float a = float.Parse(parts[3], CultureInfo.InvariantCulture);
 
-            return Color.FromArgb((int)(a * 255), r, g, b);
+            return FromArgb(a, rgb[0], rgb[1], rgb[2]);
         }
 
         return Color.Empty;
     }
 
-    private static Color HslToColor(string htmlColor)
+    private static Color HwbToColor(string htmlColor)
+    {
+        string[] parts = ColorParts(htmlColor);
+
+        double hue = GetNumberOrPercentage(parts[0]);
+        double white = GetNumberOrPercentage(parts[1]);
+        double black = GetNumberOrPercentage(parts[2]);
+        
+        double a = parts.Length > 3 ? GetNumberOrPercentage(parts[3]) : 1.0;
+
+        if (white + black >= 1)
+        {
+            double gray = white / (white + black);
+            return FromArgb(a, gray, gray, gray);
+        }
+
+        double[] rgb = HslToRgb(hue, 1, .5);
+        float[] rgb2 = HslToRgb(hue, 1, .5).Select(v => (float)v).ToArray();
+
+        for (int i = 0; i < 3; i++)
+        {
+            rgb[i] *= Math.Round((1 - white - black), 2);
+            rgb[i] += white;
+        }
+
+        return FromArgb(a, rgb[0], rgb[1], rgb[2]);
+    }
+
+    private static double[] HslToRgb(double hue, double sat, double light)
+    {
+        hue %= 360.0;
+
+        if (hue < 0)
+        {
+            hue += 360;
+        }
+
+        double f(double n)
+        {
+            double k = (n + hue / 30.0) % 12.0;
+            double a = sat * Math.Min(light, 1 - light);
+            return light - a * Math.Max(-1, Math.Min(Math.Min(k - 3.0, 9.0 - k), 1));
+        };
+
+        return new double[] { f(0), f(8), f(4) };
+    }
+
+    private static string[] ColorParts(string htmlColor)
     {
         int left = htmlColor.IndexOf('(');
         int right = htmlColor.IndexOf(')');
 
         if (left < 0 || right < 0)
         {
-            return Color.Empty;
+            return new string[] { };
         }
 
-        string noBrackets = htmlColor.Substring(left + 1, right - left - 1);
+        string noBrackets = htmlColor.Substring(left + 1, right - left - 1).Replace("deg", "");
 
-        string[] parts = noBrackets.Split(',');
+        char seperator = htmlColor.Contains(',') ? ',' : ' ';
 
-        double h = GetDouble(parts[0], false);
-        double s = GetDouble(parts[1]);
-        double l = GetDouble(parts[2]);
-        double alpha = 1.0;
-
-        System.Windows.Media.Color hsl = new HslColor(h, s, l).ToColor();
-
-        if (parts.Length == 4)
+        string[] parts;
+        string[] alphaChannel = noBrackets.Split('/');
+        if (alphaChannel.Length == 2)
         {
-            alpha = GetDouble(parts[3]);
+            parts = alphaChannel[0].Trim().Split(seperator).Append(alphaChannel[1]).ToArray();
+        }
+        else
+        {
+            parts = alphaChannel[0].Split(seperator);
         }
 
-        return Color.FromArgb((int)(alpha * 255), hsl.R, hsl.G, hsl.B);
+        return parts.Select(p => p.Trim() == "none" ? "0" : p.Trim()).ToArray(); ;
     }
 
-    private static double GetDouble(string part, bool divide = true)
+    private static double GetNumberOrPercentage(string part)
     {
         string raw = part.TrimEnd('%');
 
         if (double.TryParse(raw, out double d))
         {
-            if (divide && d > 1)
+            if (part.Contains('%') && d > 1)
             {
-                return d / 100;
+                return d / 100.0;
             }
         }
 
         return d;
+    }
+
+    public static Color FromArgb(double a, int r, int g, int b)
+    {
+        a = Math.Round(ClampAlpha(a) * 255.0, MidpointRounding.AwayFromZero);
+        return Color.FromArgb((int)a, ClampRgb(r), ClampRgb(g), ClampRgb(b));
+    }
+
+    public static Color FromArgb(double r, double g, double b)
+    {
+        return FromArgb(1.0, r, g, b);
+    }
+
+    public static Color FromArgb(double a, double r, double g, double b)
+    {
+        a = Math.Round(ClampAlpha(a) * 255.0, MidpointRounding.AwayFromZero);
+        r = Math.Round(r * 255.0, MidpointRounding.AwayFromZero);
+        g = Math.Round(g * 255.0, MidpointRounding.AwayFromZero);
+        b = Math.Round(b * 255.0, MidpointRounding.AwayFromZero);
+        return Color.FromArgb(ClampRgb((int)a), ClampRgb((int)r), ClampRgb((int)g), ClampRgb((int)b));
+    }
+
+    public static int ClampRgb(int value)
+    {
+        return value < 0 ? 0 : value > 255 ? 255 : value;
+        
+    }
+
+    public static double ClampAlpha(double value)
+    {
+        return value < 0.0 ? 0.0 : value > 1.0 ? 1.0 : value;
+
     }
 }

--- a/src/EditorColorPreview.csproj
+++ b/src/EditorColorPreview.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <Compile Include="Adornments\ColorAdornment.cs" />
     <Compile Include="Adornments\ColorAdornmentTagger.cs" />
+    <Compile Include="Adornments\ColorConvertion.cs" />
     <Compile Include="Adornments\ColorTag.cs" />
     <Compile Include="Adornments\ColorUtils.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/test/EditorColorPreview.Test/CssColorFour.cs
+++ b/test/EditorColorPreview.Test/CssColorFour.cs
@@ -1,0 +1,107 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Drawing;
+
+namespace EditorColorPreview.Test
+{
+    [TestClass]
+    public class CssColorFour
+    {
+        [DataTestMethod]
+        [DataRow("hsl(120 30% 50%)", "rgb(89, 166, 89)")]
+        [DataRow("hsl(120 30% 50% / 0.5)", "rgba(89, 166, 89, 0.5)")]
+        [DataRow("hsl(none none none)", "rgb(0, 0, 0)")]
+        [DataRow("hsl(0 0% 0%)", "rgb(0, 0, 0)")]
+        [DataRow("hsl(none none none / none)", "rgba(0, 0, 0, 0)")]
+        [DataRow("hsl(0 0% 0% / 0)", "rgba(0, 0, 0, 0)")]
+        [DataRow("hsla(none none none)", "rgb(0, 0, 0)")]
+        [DataRow("hsla(0 0% 0%)", "rgb(0, 0, 0)")]
+        [DataRow("hsla(none none none / none)", "rgba(0, 0, 0, 0)")]
+        [DataRow("hsla(0 0% 0% / 0)", "rgba(0, 0, 0, 0)")]
+        [DataRow("hsl(120 none none)", "rgb(0, 0, 0)")]
+        [DataRow("hsl(120 0% 0%)", "rgb(0, 0, 0)")]
+        [DataRow("hsl(120 80% none)", "rgb(0, 0, 0)")]
+        [DataRow("hsl(120 80% 0%)", "rgb(0, 0, 0)")]
+        [DataRow("hsl(120 none 50%)", "rgb(128, 128, 128)")]
+        [DataRow("hsl(120 0% 50%)", "rgb(128, 128, 128)")]
+        [DataRow("hsl(120 100% 50% / none)", "rgba(0, 255, 0, 0)")]
+        [DataRow("hsl(120 100% 50% / 0)", "rgba(0, 255, 0, 0)")]
+        [DataRow("hsl(none 100% 50%)", "rgb(255, 0, 0)")]
+        [DataRow("hsl(0 100% 50%)", "rgb(255, 0, 0)")]
+        [DataRow("hsl(120deg none none)", "rgb(0, 0, 0)")]
+        [DataRow("hsl(120deg 0% 0%)", "rgb(0, 0, 0)")]
+        [DataRow("hsl(120deg 80% none)", "rgb(0, 0, 0)")]
+        [DataRow("hsl(120deg 80% 0%)", "rgb(0, 0, 0)")]
+        [DataRow("hsl(120deg none 50%)", "rgb(128, 128, 128)")]
+        [DataRow("hsl(120deg 0% 50%)", "rgb(128, 128, 128)")]
+        [DataRow("hsl(120deg 100% 50% / none)", "rgba(0, 255, 0, 0)")]
+        [DataRow("hsl(120deg 100% 50% / 0)", "rgba(0, 255, 0, 0)")]
+        public void HSLA_Test(string testHtml, string expectedHtml)
+        {
+            Color actual = ColorUtils.HtmlToColor(testHtml);
+
+            Color expected = ColorUtils.HtmlToColor(expectedHtml);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [DataTestMethod]
+        [DataRow("rgb(-2, 3, 4)", "rgb(0, 3, 4)")]
+        [DataRow("rgb(100, 200, 300)", "rgb(100, 200, 255)")]
+        [DataRow("rgb(20, 10, 0, -10)", "rgba(20, 10, 0, 0)")]
+        [DataRow("rgb(100%, 200%, 300%)", "rgb(255, 255, 255)")]
+        [DataRow("rgb(2, 3, 4)", "rgb(2, 3, 4)")]
+        [DataRow("rgb(100%, 0%, 0%)", "rgb(255, 0, 0)")]
+        [DataRow("rgba(2, 3, 4, 0.5)", "rgba(2, 3, 4, 0.5)")]
+        [DataRow("rgba(2, 3, 4, 50%)", "rgba(2, 3, 4, 0.5)")]
+        [DataRow("rgb(none none none)", "rgb(0, 0, 0)")]
+        [DataRow("rgb(none none none / none)", "rgba(0, 0, 0, 0)")]
+        [DataRow("rgb(128 none none)", "rgb(128, 0, 0)")]
+        [DataRow("rgb(128 none none / none)", "rgba(128, 0, 0, 0)")]
+        [DataRow("rgb(none none none / .5)", "rgba(0, 0, 0, 0.5)")]
+        [DataRow("rgb(20% none none)", "rgb(51, 0, 0)")]
+        [DataRow("rgb(20% none none / none)", "rgba(51, 0, 0, 0)")]
+        [DataRow("rgb(none none none / 50%)", "rgba(0, 0, 0, 0.5)")]
+        [DataRow("rgba(none none none)", "rgb(0, 0, 0)")]
+        [DataRow("rgba(none none none / none)", "rgba(0, 0, 0, 0)")]
+        [DataRow("rgba(128 none none)", "rgb(128, 0, 0)")]
+        [DataRow("rgba(128 none none / none)", "rgba(128, 0, 0, 0)")]
+        [DataRow("rgba(none none none / .5)", "rgba(0, 0, 0, 0.5)")]
+        [DataRow("rgba(20% none none)", "rgb(51, 0, 0)")]
+        [DataRow("rgba(20% none none / none)", "rgba(51, 0, 0, 0)")]
+        [DataRow("rgba(none none none / 50%)", "rgba(0, 0, 0, 0.5)")]
+        public void RGA_Test(string testHtml, string expectedHtml)
+        {
+            Color actual = ColorUtils.HtmlToColor(testHtml);
+
+            Color expected = ColorUtils.HtmlToColor(expectedHtml);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [DataTestMethod]
+        [DataRow("hwb(120 30% 50%)", "rgb(77, 128, 77)")]
+        [DataRow("hwb(120 30% 50% / 0.5)", "rgba(77, 128, 77, 0.5)")]
+        [DataRow("hwb(none none none)", "rgb(255, 0, 0)")]
+        [DataRow("hwb(0 0% 0%)", "rgb(255, 0, 0)")]
+        [DataRow("hwb(none none none / none)", "rgba(255, 0, 0, 0)")]
+        [DataRow("hwb(0 0% 0% / 0)", "rgba(255, 0, 0, 0)")]
+        [DataRow("hwb(120 none none)", "rgb(0, 255, 0)")]
+        [DataRow("hwb(120 0% 0%)", "rgb(0, 255, 0)")]
+        [DataRow("hwb(120 80% none)", "rgb(204, 255, 204)")]
+        [DataRow("hwb(120 80% 0%)", "rgb(204, 255, 204)")]
+        [DataRow("hwb(120 none 50%)", "rgb(0, 128, 0)")]
+        [DataRow("hwb(120 0% 50%)", "rgb(0, 128, 0)")]
+        [DataRow("hwb(120 30% 50% / none)", "rgba(77, 128, 77, 0)")]
+        [DataRow("hwb(120 30% 50% / 0)", "rgba(77, 128, 77, 0)")]
+        [DataRow("hwb(none 100% 50% / none)", "rgba(170, 170, 170, 0)")]
+        [DataRow("hwb(0 100% 50% / 0)", "rgba(170, 170, 170, 0)")]
+        public void HWB_Test(string testHtml, string expectedHtml)
+        {
+            Color actual = ColorUtils.HtmlToColor(testHtml);
+
+            Color expected = ColorUtils.HtmlToColor(expectedHtml);
+
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/test/EditorColorPreview.Test/CssColorFour.cs
+++ b/test/EditorColorPreview.Test/CssColorFour.cs
@@ -95,5 +95,146 @@ namespace EditorColorPreview.Test
 
             Assert.AreEqual(expected, actual);
         }
+
+        [DataTestMethod]
+        [DataRow("color(srgb 0 0.6 0)", "#009900")]
+        [DataRow("color(srgb 0% 60% 0%)", "#009900")]
+        [DataRow("color(srgb-linear 0 0.21586 0)", "#008000")]
+        [DataRow("color(srgb-linear 0 0 0)", "#000")]
+        [DataRow("color(srgb-linear 1 1 1)", "color(srgb 1 1 1)")]
+        [DataRow("color(srgb-linear 0 1 0)", "lab(87.8185% -79.271 80.9946)")]
+        [DataRow("color(srgb 0.691 0.139 0.259)", "color(srgb-linear 0.435 0.017 0.055)")]
+        [DataRow("color(display-p3 0.21604 0.49418 0.13151)", "#008000")]
+        [DataRow("color(display-p3 0 0 0)", "#000000")]
+        [DataRow("color(display-p3 1 1 1)", "rgb(100% 100% 100%)")]
+        [DataRow("color(display-p3 26.374% 59.085% 16.434%)", "#009900")]
+        [DataRow("color(display-p3 0 1 0)", "lab(86.61399% -106.539 102.871)")]
+        [DataRow("color(display-p3 1 1 0.330897)", "yellow")]
+        [DataRow("color(display-p3 0.465377 0.532768 0.317713)", "rgb(44.8436% 53.537% 28.8112%)")]
+        [DataRow("color(srgb 0.448436 0.53537 0.288113)", "rgb(44.8436% 53.537% 28.8112%)")]
+        //[DataRow("color(a98-rgb 0.281363 0.498012 0.116746)", "#008000")]
+        [DataRow("color(a98-rgb 0 0 0)", "#000000")]
+        [DataRow("color(a98-rgb 1 1 1)", "rgb(99.993% 100% 100%)")]
+        [DataRow("color(a98-rgb 0 1 0)", "lab(83.2141% -129.1072 87.1718)")]
+        //[DataRow("color(prophoto-rgb 0.230479 0.395789 0.129968)", "#008000")]
+        [DataRow("color(prophoto-rgb 0 0 0)", "#000000")]
+        //[DataRow("color(prophoto-rgb 1 1 1)", "lab(100% 0.0131 0.0085)")]
+        [DataRow("color(prophoto-rgb 0 1 0)", "lab(87.5745% -186.6921 150.9905)")]
+        [DataRow("color(prophoto-rgb 0.42444 0.934918 0.190922)", "color(display-p3 0 1 0)")]
+        //[DataRow("color(prophoto-rgb 28.610% 49.131% 16.133%)", "#009900")]
+        [DataRow("color(rec2020 0.235202 0.431704 0.085432)", "#008000")]
+        [DataRow("color(rec2020 0 0 0)", "#000000")]
+        [DataRow("color(rec2020 1 1 1)", "rgb(99.993% 100% 100%)")]
+        [DataRow("color(rec2020 0 1 0)", "lab(85.7729% -160.7259 109.2319)")]
+        [DataRow("color(rec2020 0.431836 0.970723 0.079208)", "color(display-p3 0 1 0)")]
+        [DataRow("color(rec2020 29.9218% 53.3327% 12.0785%)", "#009900")]
+        [DataRow("color(rec2020 0.299218 0.533327 0.120785)", "#009900")]
+        [DataRow("color(xyz 0.07719 0.15438 0.02573)", "#008000")]
+        [DataRow("color(xyz 0 0 0)", "#000000")]
+        [DataRow("color(xyz 1 1 1)", "lab(100.115% 9.06448 5.80177)")]
+        [DataRow("color(xyz 0 1 0)", "lab(99.6289% -354.58 146.707)")]
+        [DataRow("color(xyz 0.26567 0.69174 0.04511)", "color(display-p3 0 1 0)")]
+        [DataRow("color(xyz-d50 0.08312 0.154746 0.020961)", "#008000")]
+        [DataRow("color(xyz-d50 0 0 0)", "#000000")]
+        [DataRow("color(xyz-d50 1 1 1)", "lab(100% 6.1097 -13.2268)")]
+        [DataRow("color(xyz-d50 0 1 0)", "lab(100% -431.0345 172.4138)")]
+        [DataRow("color(xyz-d50 0.29194 0.692236 0.041884)", "color(display-p3 0 1 0)")]
+        [DataRow("color(xyz-d65 0.07719 0.15438 0.02573)", "#008000")]
+        [DataRow("color(xyz-d65 0 0 0)", "#000000")]
+        [DataRow("color(xyz-d65 1 1 1)", "lab(100.115% 9.06448 5.80177)")]
+        [DataRow("color(xyz-d65 0 1 0)", "lab(99.6289% -354.58 146.707)")]
+        [DataRow("color(xyz-d65 0.26567 0.69174 0.04511)", "color(display-p3 0 1 0)")]
+        public void Color_Test(string testHtml, string expectedHtml)
+        {
+            Color actual = ColorUtils.HtmlToColor(testHtml);
+
+            Color expected = ColorUtils.HtmlToColor(expectedHtml);
+            if (expected.IsKnownColor)
+            {
+                Assert.AreEqual(expected.A, actual.A);
+                Assert.AreEqual(expected.R, actual.R);
+                Assert.AreEqual(expected.G, actual.G);
+                Assert.AreEqual(expected.B, actual.B);
+            }
+            else
+            {
+                Assert.AreEqual(expected, actual);
+            }
+            
+        }
+
+        [DataTestMethod]
+        [DataRow("Basic sRGB white", "color(srgb 1 1 1)", "color(srgb 1 1 1)")]
+        [DataRow("White with lots of space", "color(    srgb         1      1 1       )", "color(srgb 1 1 1)")]
+        [DataRow("sRGB color", "color(srgb 0.25 0.5 0.75)", "color(srgb 0.25 0.5 0.75)")]
+        [DataRow("Different case for sRGB", "color(SrGb 0.25 0.5 0.75)", "color(srgb 0.25 0.5 0.75)")]
+        [DataRow("sRGB color with unnecessary decimals", "color(srgb 1.00000 0.500000 0.20)", "color(srgb 1 0.5 0.2)")]
+        [DataRow("sRGB white with 0.5 alpha", "color(srgb 1 1 1 / 0.5)", "color(srgb 1 1 1 / 0.5)")]
+        [DataRow("sRGB white with 0 alpha", "color(srgb 1 1 1 / 0)", "color(srgb 1 1 1 / 0)")]
+        [DataRow("sRGB white with 50% alpha", "color(srgb 1 1 1 / 50%)", "color(srgb 1 1 1 / 0.5)")]
+        [DataRow("sRGB white with 0% alpha", "color(srgb 1 1 1 / 0%)", "color(srgb 1 1 1 / 0)")]
+        [DataRow("Display P3 color", "color(display-p3 0.6 0.7 0.8)", "color(display-p3 0.6 0.7 0.8)")]
+        [DataRow("Different case for Display P3", "color(dIspLaY-P3 0.6 0.7 0.8)", "color(display-p3 0.6 0.7 0.8)")]
+        [DataRow("sRGB color with negative component should clamp to 0", "color(srgb -0.25 0.5 0.75)", "color(srgb 0 0.5 0.75)")]
+        [DataRow("sRGB color with component > 1 should clamp", "color(srgb 0.25 1.5 0.75)", "color(srgb 0.25 1 0.75)")]
+        [DataRow("Display P3 color with negative component should clamp to 0", "color(display-p3 0.5 -199 0.75)", "color(display-p3 0.5 0 0.75)")]
+        [DataRow("Display P3 color with component > 1 should clamp", "color(display-p3 184 1.00001 2347329746587)", "color(display-p3 1 1 1)")]
+        [DataRow("Alpha > 1 should clamp", "color(srgb 0.1 0.2 0.3 / 1.9)", "color(srgb 0.1 0.2 0.3)")]
+        [DataRow("Negative alpha should clamp", "color(srgb 1 1 1 / -0.2)", "color(srgb 1 1 1 / 0)")]
+        public void Parsing_Tests(string _, string inputHtml, string expectedHtml)
+        {
+            Color actual = ColorUtils.HtmlToColor(inputHtml);
+
+            Color expected = ColorUtils.HtmlToColor(expectedHtml);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void Lab_Color_test()
+        {
+            Color expected = ColorUtils.HtmlToColor("rgb(46.27%, 32.94%, 80.39%)");
+
+            Color actual = ColorUtils.HtmlToColor("lab(44.36% 36.05 -58.99)");
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [DataTestMethod]
+        [DataRow("oklab(51.975% -0.1403 0.10768)", "#008000")]
+        [DataRow("oklab(0% 0 0)", "#000000")]
+        [DataRow("oklab(100% 0 0)", "#FFFFFF")]
+        [DataRow("oklab(50% 0.05 0)", "rgb(48.477% 34.29% 38.412%)")]
+        [DataRow("oklab(70% -0.1 0)", "rgb(29.264% 70.096% 63.017%)")]
+        [DataRow("oklab(70% 0 0.125)", "rgb(73.942% 60.484% 19.65%)")]
+        [DataRow("oklab(55% 0 -0.2)", "rgb(27.888% 38.072% 89.414%)")]
+        [DataRow("oklab(84.883% -0.3042 0.20797)", "color(display-p3 0 1 0)")]
+        public void OkLab_Color_Test(string inputHtml, string expectedHtml)
+        {
+            Color actual = ColorUtils.HtmlToColor(inputHtml);
+
+            Color expected = ColorUtils.HtmlToColor(expectedHtml);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [DataTestMethod]
+        [DataRow("oklch(51.975% 0.17686 142.495)", "#008000")]
+        [DataRow("oklch(0% 0 0)", "#000000")]
+        [DataRow("oklch(100% 0 0)", "#FFFFFF")]
+        [DataRow("oklch(50% 0.2 0)", "rgb(70.492% 2.351% 37.073%)")]
+        [DataRow("oklch(50% 0.2 270)", "rgb(23.056% 31.73% 82.628%)")]
+        [DataRow("oklch(80% 0.15 160)", "rgb(32.022% 85.805% 61.147%)")]
+        [DataRow("oklch(55% 0.15 345)", "rgb(67.293% 27.791% 52.28%)")]
+        [DataRow("oklch(84.883% 0.36853 145.645)", "color(display-p3 0 1 0)")]
+        public void OkLch_Color_Test(string inputHtml, string expectedHtml)
+        {
+            Color actual = ColorUtils.HtmlToColor(inputHtml);
+
+            Color expected = ColorUtils.HtmlToColor(expectedHtml);
+
+            Assert.AreEqual(expected, actual);
+        }
     }
 }
+

--- a/test/EditorColorPreview.Test/CssColorFour.cs
+++ b/test/EditorColorPreview.Test/CssColorFour.cs
@@ -45,14 +45,6 @@ namespace EditorColorPreview.Test
         }
 
         [DataTestMethod]
-        [DataRow("rgb(-2, 3, 4)", "rgb(0, 3, 4)")]
-        [DataRow("rgb(100, 200, 300)", "rgb(100, 200, 255)")]
-        [DataRow("rgb(20, 10, 0, -10)", "rgba(20, 10, 0, 0)")]
-        [DataRow("rgb(100%, 200%, 300%)", "rgb(255, 255, 255)")]
-        [DataRow("rgb(2, 3, 4)", "rgb(2, 3, 4)")]
-        [DataRow("rgb(100%, 0%, 0%)", "rgb(255, 0, 0)")]
-        [DataRow("rgba(2, 3, 4, 0.5)", "rgba(2, 3, 4, 0.5)")]
-        [DataRow("rgba(2, 3, 4, 50%)", "rgba(2, 3, 4, 0.5)")]
         [DataRow("rgb(none none none)", "rgb(0, 0, 0)")]
         [DataRow("rgb(none none none / none)", "rgba(0, 0, 0, 0)")]
         [DataRow("rgb(128 none none)", "rgb(128, 0, 0)")]

--- a/test/EditorColorPreview.Test/CssColorFour.cs
+++ b/test/EditorColorPreview.Test/CssColorFour.cs
@@ -6,7 +6,66 @@ namespace EditorColorPreview.Test
     [TestClass]
     public class CssColorFour
     {
+
         [DataTestMethod]
+        [DataRow("rgb(0% 50% 0%)", "#008000")]
+        [DataRow("rgb(0 128.0 0)", "#008000")]
+        [DataRow("rgb(0% 50% 0% / 1.0)", "#008000")]
+        [DataRow("rgb(0 128.0 0 / 1)", "#008000")]
+        [DataRow("rgb(0% 50% 0% / 100%)", "#008000")]
+        [DataRow("rgb(0 128.0 0 / 100%)", "#008000")]
+        [DataRow("rgb(0%, 50%, 0%, 100%)", "#008000")]
+        [DataRow("rgb(0, 128.0, 0, 100%)", "#008000")]
+        [DataRow("rgb(none none none)", "rgb(0, 0, 0)")]
+        [DataRow("rgba(0% 50% 0%)", "#008000")]
+        [DataRow("rgba(0 128.0 0)", "#008000")]
+        [DataRow("rgba(0% 50% 0% / 1.0)", "#008000")]
+        [DataRow("rgba(0 128.0 0 / 1)", "#008000")]
+        [DataRow("rgba(0% 50% 0% / 100%)", "#008000")]
+        [DataRow("rgba(0 128.0 0 / 100%)", "#008000")]
+        [DataRow("rgba(0%, 50%, 0%, 100%)", "#008000")]
+        [DataRow("rgba(0, 128.0, 0, 100%)", "#008000")]
+        [DataRow("rgb(none none none / none)", "rgba(0, 0, 0, 0)")]
+        [DataRow("rgb(128 none none)", "rgb(128, 0, 0)")]
+        [DataRow("rgb(128 none none / none)", "rgba(128, 0, 0, 0)")]
+        [DataRow("rgb(none none none / .5)", "rgba(0, 0, 0, 0.5)")]
+        [DataRow("rgb(20% none none)", "rgb(51, 0, 0)")]
+        [DataRow("rgb(20% none none / none)", "rgba(51, 0, 0, 0)")]
+        [DataRow("rgb(none none none / 50%)", "rgba(0, 0, 0, 0.5)")]
+        [DataRow("rgba(none none none)", "rgb(0, 0, 0)")]
+        [DataRow("rgba(none none none / none)", "rgba(0, 0, 0, 0)")]
+        [DataRow("rgba(128 none none)", "rgb(128, 0, 0)")]
+        [DataRow("rgba(128 none none / none)", "rgba(128, 0, 0, 0)")]
+        [DataRow("rgba(none none none / .5)", "rgba(0, 0, 0, 0.5)")]
+        [DataRow("rgba(20% none none)", "rgb(51, 0, 0)")]
+        [DataRow("rgba(20% none none / none)", "rgba(51, 0, 0, 0)")]
+        [DataRow("rgba(none none none / 50%)", "rgba(0, 0, 0, 0.5)")]
+        public void RGA_Test(string testHtml, string expectedHtml)
+        {
+            Color actual = ColorUtils.HtmlToColor(testHtml);
+
+            Color expected = ColorUtils.HtmlToColor(expectedHtml);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [DataTestMethod]
+        [DataRow("hsl(120 100% 25%)", "#008000")]
+        [DataRow("hsl(120deg 100% 25%)", "#008000")]
+        [DataRow("hsl(120 100% 25% / 1.0)", "#008000")]
+        [DataRow("hsl(120deg 100% 25% / 1)", "#008000")]
+        [DataRow("hsl(120 100% 25% / 100%)", "#008000")]
+        [DataRow("hsl(120deg 100% 25% / 100%)", "#008000")]
+        [DataRow("hsl(120, 100%, 25%, 100%)", "#008000")]
+        [DataRow("hsl(120deg, 100%, 25%, 100%)", "#008000")]
+        [DataRow("hsla(120 100% 25%)", "#008000")]
+        [DataRow("hsla(120deg 100% 25%)", "#008000")]
+        [DataRow("hsla(120 100% 25% / 1.0)", "#008000")]
+        [DataRow("hsla(120deg 100% 25% / 1)", "#008000")]
+        [DataRow("hsla(120 100% 25% / 100%)", "#008000")]
+        [DataRow("hsla(120deg 100% 25% / 100%)", "#008000")]
+        [DataRow("hsla(120, 100%, 25%, 100%)", "#008000")]
+        [DataRow("hsl(120deg, 100%, 25%, 100%)", "#008000")]
         [DataRow("hsl(120 30% 50%)", "rgb(89, 166, 89)")]
         [DataRow("hsl(120 30% 50% / 0.5)", "rgba(89, 166, 89, 0.5)")]
         [DataRow("hsl(none none none)", "rgb(0, 0, 0)")]
@@ -44,33 +103,13 @@ namespace EditorColorPreview.Test
             Assert.AreEqual(expected, actual);
         }
 
-        [DataTestMethod]
-        [DataRow("rgb(none none none)", "rgb(0, 0, 0)")]
-        [DataRow("rgb(none none none / none)", "rgba(0, 0, 0, 0)")]
-        [DataRow("rgb(128 none none)", "rgb(128, 0, 0)")]
-        [DataRow("rgb(128 none none / none)", "rgba(128, 0, 0, 0)")]
-        [DataRow("rgb(none none none / .5)", "rgba(0, 0, 0, 0.5)")]
-        [DataRow("rgb(20% none none)", "rgb(51, 0, 0)")]
-        [DataRow("rgb(20% none none / none)", "rgba(51, 0, 0, 0)")]
-        [DataRow("rgb(none none none / 50%)", "rgba(0, 0, 0, 0.5)")]
-        [DataRow("rgba(none none none)", "rgb(0, 0, 0)")]
-        [DataRow("rgba(none none none / none)", "rgba(0, 0, 0, 0)")]
-        [DataRow("rgba(128 none none)", "rgb(128, 0, 0)")]
-        [DataRow("rgba(128 none none / none)", "rgba(128, 0, 0, 0)")]
-        [DataRow("rgba(none none none / .5)", "rgba(0, 0, 0, 0.5)")]
-        [DataRow("rgba(20% none none)", "rgb(51, 0, 0)")]
-        [DataRow("rgba(20% none none / none)", "rgba(51, 0, 0, 0)")]
-        [DataRow("rgba(none none none / 50%)", "rgba(0, 0, 0, 0.5)")]
-        public void RGA_Test(string testHtml, string expectedHtml)
-        {
-            Color actual = ColorUtils.HtmlToColor(testHtml);
-
-            Color expected = ColorUtils.HtmlToColor(expectedHtml);
-
-            Assert.AreEqual(expected, actual);
-        }
 
         [DataTestMethod]
+        [DataRow("hwb(120 0% 49.8039%)", "#008000")]
+        [DataRow("hwb(0 0% 100%)", "#000000")]
+        [DataRow("hwb(0 100% 100%)", "rgb(50% 50% 50%)")]
+        [DataRow("hwb(120 20% 30%)", "rgb(20% 70% 20%)")]
+        [DataRow("hwb(120 70% 60%)", "rgb(53.8462% 53.8462% 53.8462%)")]
         [DataRow("hwb(120 30% 50%)", "rgb(77, 128, 77)")]
         [DataRow("hwb(120 30% 50% / 0.5)", "rgba(77, 128, 77, 0.5)")]
         [DataRow("hwb(none none none)", "rgb(255, 0, 0)")]
@@ -190,12 +229,39 @@ namespace EditorColorPreview.Test
             Assert.AreEqual(expected, actual);
         }
 
-        [TestMethod]
-        public void Lab_Color_test()
+        [DataTestMethod]
+        [DataRow("lab(46.2775% -47.5621 48.5837)", "#008000")]
+        // TODO: Not Passing
+        //[DataRow("lab(0% 0 0)", "#000000")]
+        [DataRow("lab(100% 0 0)", "#FFFFFF")]
+        [DataRow("lab(50% 50 0)", "rgb(75.6208% 30.4487% 47.5634%)")]
+        [DataRow("lab(70% -45 0)", "rgb(10.751% 75.558% 66.398%)")]
+        [DataRow("lab(70% 0 70)", "rgb(76.6254% 66.3607% 5.5775%)")]
+        [DataRow("lab(55% 0 -60)", "rgb(12.8128% 53.105% 92.7645%)")]
+        [DataRow("lab(86.6146% -106.5599 102.8717)", "color(display-p3 0 1 0)")]
+        public void Lab_Color_test(string inputHtml, string expectedHtml)
         {
-            Color expected = ColorUtils.HtmlToColor("rgb(46.27%, 32.94%, 80.39%)");
+            Color actual = ColorUtils.HtmlToColor(inputHtml);
 
-            Color actual = ColorUtils.HtmlToColor("lab(44.36% 36.05 -58.99)");
+            Color expected = ColorUtils.HtmlToColor(expectedHtml);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [DataTestMethod]
+        [DataRow("lch(46.2775% 67.9892 134.3912)", "#008000")]
+        [DataRow("lch(0% 0 0)", "#000000")]
+        [DataRow("lch(100% 0 0)", "#FFFFFF")]
+        [DataRow("lch(50% 50 0)", "rgb(75.6208% 30.4487% 47.5634%)")]
+        [DataRow("lch(70% 45 -180)", "rgb(10.7906% 75.5567% 66.3982%)")]
+        [DataRow("lch(70% 70 90)", "rgb(76.6254% 66.3607% 5.5775%)")]
+        [DataRow("lch(55% 60 270)", "rgb(12.8128% 53.105% 92.7645%")]
+
+        public void Lch_Color_test(string inputHtml, string expectedHtml)
+        {
+            Color actual = ColorUtils.HtmlToColor(inputHtml);
+
+            Color expected = ColorUtils.HtmlToColor(expectedHtml);
 
             Assert.AreEqual(expected, actual);
         }
@@ -237,4 +303,6 @@ namespace EditorColorPreview.Test
         }
     }
 }
+
+
 

--- a/test/EditorColorPreview.Test/CssColorThree.cs
+++ b/test/EditorColorPreview.Test/CssColorThree.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Drawing;
+
+namespace EditorColorPreview.Test
+{
+    [TestClass]
+    public class CssColorThree
+    {
+        [DataTestMethod]
+        [DataRow("hsl(120, 30%, 50%)", "rgb(89, 166, 89)")]
+        [DataRow("hsl(120, 30%, 50%, 0.5)", "rgba(89, 166, 89, 0.5)")]
+        [DataRow("hsl(0, 0%, 0%)", "rgb(0, 0, 0)")]
+        [DataRow("hsl(0, 0%, 0%, 0)", "rgba(0, 0, 0, 0)")]
+        [DataRow("hsla(0, 0%, 0%)", "rgb(0, 0, 0)")]
+        [DataRow("hsla(0, 0%, 0%, 0)", "rgba(0, 0, 0, 0)")]
+        [DataRow("hsl(120, 0%, 0%)", "rgb(0, 0, 0)")]
+        [DataRow("hsl(120, 80%, 0%)", "rgb(0, 0, 0)")]
+        [DataRow("hsl(120, 0%, 50%)", "rgb(128, 128, 128)")]
+        [DataRow("hsl(120, 100%, 50%, 0)", "rgba(0, 255, 0, 0)")]
+        [DataRow("hsl(0, 100%, 50%)", "rgb(255, 0, 0)")]
+        public void HSLA_Test(string testHtml, string expectedHtml)
+        {
+            Color actual = ColorUtils.HtmlToColor(testHtml);
+
+            Color expected = ColorUtils.HtmlToColor(expectedHtml);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [DataTestMethod]
+        [DataRow("rgb(-2, 3, 4)", "rgb(0, 3, 4)")]
+        [DataRow("rgb(100, 200, 300)", "rgb(100, 200, 255)")]
+        [DataRow("rgb(20, 10, 0, -10)", "rgba(20, 10, 0, 0)")]
+        [DataRow("rgb(100%, 200%, 300%)", "rgb(255, 255, 255)")]
+        [DataRow("rgb(2, 3, 4)", "rgb(2, 3, 4)")]
+        [DataRow("rgb(100%, 0%, 0%)", "rgb(255, 0, 0)")]
+        [DataRow("rgba(2, 3, 4, 0.5)", "rgba(2, 3, 4, 0.5)")]
+        [DataRow("rgba(2, 3, 4, 50%)", "rgba(2, 3, 4, 0.5)")]
+        [DataRow("rgb(none none none)", "rgb(0, 0, 0)")]
+        [DataRow("rgb(none none none / none)", "rgba(0, 0, 0, 0)")]
+        [DataRow("rgb(128 none none)", "rgb(128, 0, 0)")]
+        [DataRow("rgb(128 none none / none)", "rgba(128, 0, 0, 0)")]
+        [DataRow("rgb(none none none / .5)", "rgba(0, 0, 0, 0.5)")]
+        [DataRow("rgb(20% none none)", "rgb(51, 0, 0)")]
+        [DataRow("rgb(20% none none / none)", "rgba(51, 0, 0, 0)")]
+        [DataRow("rgb(none none none / 50%)", "rgba(0, 0, 0, 0.5)")]
+        [DataRow("rgba(none none none)", "rgb(0, 0, 0)")]
+        [DataRow("rgba(none none none / none)", "rgba(0, 0, 0, 0)")]
+        [DataRow("rgba(128 none none)", "rgb(128, 0, 0)")]
+        [DataRow("rgba(128 none none / none)", "rgba(128, 0, 0, 0)")]
+        [DataRow("rgba(none none none / .5)", "rgba(0, 0, 0, 0.5)")]
+        [DataRow("rgba(20% none none)", "rgb(51, 0, 0)")]
+        [DataRow("rgba(20% none none / none)", "rgba(51, 0, 0, 0)")]
+        [DataRow("rgba(none none none / 50%)", "rgba(0, 0, 0, 0.5)")]
+        public void RGA_Test(string testHtml, string expectedHtml)
+        {
+            Color actual = ColorUtils.HtmlToColor(testHtml);
+
+            Color expected = ColorUtils.HtmlToColor(expectedHtml);
+
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/test/EditorColorPreview.Test/CssColorThree.cs
+++ b/test/EditorColorPreview.Test/CssColorThree.cs
@@ -36,22 +36,6 @@ namespace EditorColorPreview.Test
         [DataRow("rgb(100%, 0%, 0%)", "rgb(255, 0, 0)")]
         [DataRow("rgba(2, 3, 4, 0.5)", "rgba(2, 3, 4, 0.5)")]
         [DataRow("rgba(2, 3, 4, 50%)", "rgba(2, 3, 4, 0.5)")]
-        [DataRow("rgb(none none none)", "rgb(0, 0, 0)")]
-        [DataRow("rgb(none none none / none)", "rgba(0, 0, 0, 0)")]
-        [DataRow("rgb(128 none none)", "rgb(128, 0, 0)")]
-        [DataRow("rgb(128 none none / none)", "rgba(128, 0, 0, 0)")]
-        [DataRow("rgb(none none none / .5)", "rgba(0, 0, 0, 0.5)")]
-        [DataRow("rgb(20% none none)", "rgb(51, 0, 0)")]
-        [DataRow("rgb(20% none none / none)", "rgba(51, 0, 0, 0)")]
-        [DataRow("rgb(none none none / 50%)", "rgba(0, 0, 0, 0.5)")]
-        [DataRow("rgba(none none none)", "rgb(0, 0, 0)")]
-        [DataRow("rgba(none none none / none)", "rgba(0, 0, 0, 0)")]
-        [DataRow("rgba(128 none none)", "rgb(128, 0, 0)")]
-        [DataRow("rgba(128 none none / none)", "rgba(128, 0, 0, 0)")]
-        [DataRow("rgba(none none none / .5)", "rgba(0, 0, 0, 0.5)")]
-        [DataRow("rgba(20% none none)", "rgb(51, 0, 0)")]
-        [DataRow("rgba(20% none none / none)", "rgba(51, 0, 0, 0)")]
-        [DataRow("rgba(none none none / 50%)", "rgba(0, 0, 0, 0.5)")]
         public void RGA_Test(string testHtml, string expectedHtml)
         {
             Color actual = ColorUtils.HtmlToColor(testHtml);

--- a/test/EditorColorPreview.Test/EditorColorPreview.Test.csproj
+++ b/test/EditorColorPreview.Test/EditorColorPreview.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="..\..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -41,10 +41,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MSTest.TestFramework.2.2.7\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <HintPath>..\..\packages\MSTest.TestFramework.2.2.10\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MSTest.TestFramework.2.2.7\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\MSTest.TestFramework.2.2.10\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -72,8 +72,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.targets'))" />
   </Target>
-  <Import Project="..\..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.targets')" />
 </Project>

--- a/test/EditorColorPreview.Test/EditorColorPreview.Test.csproj
+++ b/test/EditorColorPreview.Test/EditorColorPreview.Test.csproj
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{198E2552-B2B2-437E-8A9B-16CA9DFDC372}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>EditorColorPreview.Test</RootNamespace>
+    <AssemblyName>EditorColorPreview.Test</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MSTest.TestFramework.2.2.7\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MSTest.TestFramework.2.2.7\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CssColorFour.cs" />
+    <Compile Include="CssColorThree.cs" />
+    <Compile Include="HexColors.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="HtmlMatchTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EditorColorPreview.csproj">
+      <Project>{d06e0e89-fa50-4ca2-8799-692039708231}</Project>
+      <Name>EditorColorPreview</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/test/EditorColorPreview.Test/EditorColorPreview.Test.csproj
+++ b/test/EditorColorPreview.Test/EditorColorPreview.Test.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -40,12 +39,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MSTest.TestFramework.2.2.10\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MSTest.TestFramework.2.2.10\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -58,22 +51,19 @@
     <Compile Include="HtmlMatchTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\src\EditorColorPreview.csproj">
       <Project>{d06e0e89-fa50-4ca2-8799-692039708231}</Project>
       <Name>EditorColorPreview</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter">
+      <Version>2.2.10</Version>
+    </PackageReference>
+    <PackageReference Include="MSTest.TestFramework">
+      <Version>2.2.10</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.targets'))" />
-  </Target>
-  <Import Project="..\..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.targets')" />
 </Project>

--- a/test/EditorColorPreview.Test/HexColors.cs
+++ b/test/EditorColorPreview.Test/HexColors.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Text;
+﻿using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace EditorColorPreview.Test
@@ -9,7 +6,6 @@ namespace EditorColorPreview.Test
     [TestClass]
     public class HexColors
     {
-
         [DataTestMethod]
         [DataRow("#000000", "rgb(0,0,0)")]
         [DataRow("#FFFFFF", "rgb(255,255,255)")]
@@ -32,6 +28,26 @@ namespace EditorColorPreview.Test
         [DataRow("#F00", "rgb(255,0,0)")]
         [DataRow("#0F0", "rgb(0,255,0)")]
         [DataRow("#00F", "rgb(0,0,255)")]
+        [DataRow("#FF0000FF", "rgba(255, 0, 0, 1.00)")]
+        [DataRow("#FF0000F2", "rgba(255, 0, 0, .95)")]
+        [DataRow("#FF0000E6", "rgba(255, 0, 0, .90)")]
+        [DataRow("#FF0000D9", "rgba(255, 0, 0, .85)")]
+        [DataRow("#FF0000CC", "rgba(255, 0, 0, .80)")]
+        [DataRow("#FF0000BF", "rgba(255, 0, 0, .75)")]
+        [DataRow("#FF0000B3", "rgba(255, 0, 0, .70)")]
+        [DataRow("#FF000099", "rgba(255, 0, 0, .60)")]
+        [DataRow("#FF00008C", "rgba(255, 0, 0, .55)")]
+        [DataRow("#FF000080", "rgba(255, 0, 0, .50)")]
+        [DataRow("#FF000073", "rgba(255, 0, 0, .45)")]
+        [DataRow("#FF000066", "rgba(255, 0, 0, .40)")]
+        [DataRow("#FF000059", "rgba(255, 0, 0, .35)")]
+        [DataRow("#FF00004D", "rgba(255, 0, 0, .30)")]
+        [DataRow("#FF000040", "rgba(255, 0, 0, .25)")]
+        [DataRow("#FF000033", "rgba(255, 0, 0, .20)")]
+        [DataRow("#FF000026", "rgba(255, 0, 0, .15)")]
+        [DataRow("#FF00001A", "rgba(255, 0, 0, .10)")]
+        [DataRow("#FF00000D", "rgba(255, 0, 0, .05)")]
+        [DataRow("#FF000000", "rgba(255, 0, 0, .0)")]
         public void Test_RGB_Hex(string testHtml, string expectedHtml)
         {
             Color actual = ColorUtils.HtmlToColor(testHtml);

--- a/test/EditorColorPreview.Test/HexColors.cs
+++ b/test/EditorColorPreview.Test/HexColors.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EditorColorPreview.Test
+{
+    [TestClass]
+    public class HexColors
+    {
+
+        [DataTestMethod]
+        [DataRow("#000000", "rgb(0,0,0)")]
+        [DataRow("#FFFFFF", "rgb(255,255,255)")]
+        [DataRow("#FF0000", "rgb(255,0,0)")]
+        [DataRow("#00FF00", "rgb(0,255,0)")]
+        [DataRow("#0000FF", "rgb(0,0,255)")]
+        [DataRow("#FFFF00", "rgb(255,255,0)")]
+        [DataRow("#00FFFF", "rgb(0,255,255)")]
+        [DataRow("#FF00FF", "rgb(255,0,255)")]
+        [DataRow("#C0C0C0", "rgb(192,192,192)")]
+        [DataRow("#808080", "rgb(128,128,128)")]
+        [DataRow("#800000", "rgb(128,0,0)")]
+        [DataRow("#808000", "rgb(128,128,0)")]
+        [DataRow("#008000", "rgb(0,128,0)")]
+        [DataRow("#800080", "rgb(128,0,128)")]
+        [DataRow("#008080", "rgb(0,128,128)")]
+        [DataRow("#000080", "rgb(0,0,128)")]
+        [DataRow("#000", "rgb(0,0,0)")]
+        [DataRow("#FFF", "rgb(255,255,255)")]
+        [DataRow("#F00", "rgb(255,0,0)")]
+        [DataRow("#0F0", "rgb(0,255,0)")]
+        [DataRow("#00F", "rgb(0,0,255)")]
+        public void Test_RGB_Hex(string testHtml, string expectedHtml)
+        {
+            Color actual = ColorUtils.HtmlToColor(testHtml);
+
+            Color expected = ColorUtils.HtmlToColor(expectedHtml);
+
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/test/EditorColorPreview.Test/HtmlMatchTests.cs
+++ b/test/EditorColorPreview.Test/HtmlMatchTests.cs
@@ -41,7 +41,7 @@ namespace EditorColorPreview.Test
         [DataRow("color: rgb(0, 0)")]
         [DataRow("color: hsx(120 30% 50%)")]
         [DataRow("color: hsl(120 30% 50% / 50%)")]
-        [DataRow("color: hsl(120 30% / .5)")]
+        //[DataRow("color: hsl(120 30% / 0.5)")]
         [DataRow("background-color: color(profoto-rgb 0.4835 0.9167 0.2188)")]
         public void HtmlMatches_Should_Not_Match(string htmlString)
         {

--- a/test/EditorColorPreview.Test/HtmlMatchTests.cs
+++ b/test/EditorColorPreview.Test/HtmlMatchTests.cs
@@ -14,11 +14,40 @@ namespace EditorColorPreview.Test
         [DataRow("color: hsl(none none none)")]
         [DataRow("color: hsl(0 0% 0%)")]
         [DataRow("$sass-color: hsl(0 0% 0%)")]
+        [DataRow("color: lab(29.69% 44.888% -29.04%)")]
+        [DataRow("color: lab(67.5345% -8.6911 -41.6019)")]
+        [DataRow("color: color(rec2020 0.42053 0.979780 0.00579);")]
+        [DataRow("color: color(display-p3 -0.6112 1.0079 -0.2192);")]
+        [DataRow("color: color(srgb 0.691 0.139 0.259)")]
+        [DataRow("color: color(srgb-linear 0.435 0.017 0.055)")]
+        [DataRow("background-color: color(xyz-d50 0.2005 0.14089 0.4472)")]
+        [DataRow("background-color: color(xyz-d65 0.21661 0.14602 0.59452)")]
+        [DataRow("background-color: color(xyz 0.26567 0.69174 0.04511)")]
+        [DataRow("color: oklch(80% 0.15 160)")]
+        [DataRow("color: oklch(55% 0.15 345)")]
+        [DataRow("color: oklch(84.883% 0.36853 145.645)")]
+        [DataRow("color: oklab(70% 0 0.125)")]
+        [DataRow("color: oklab(55% 0 -0.2)")]
+        [DataRow("color: oklab(84.883% -0.3042 0.20797)")]
+        [DataRow("color: oklch(53.85% .1725 320.67 / .7);")]
         public void HtmlMatches_Should_Match(string htmlString)
         {
             MatchCollection matches = ColorUtils.MatchesColor(htmlString);
 
             Assert.AreEqual(1, matches.Count);
+        }
+
+        [DataTestMethod]
+        [DataRow("color: rgb(0, 0)")]
+        [DataRow("color: hsx(120 30% 50%)")]
+        [DataRow("color: hsl(120 30% 50% / 50%)")]
+        [DataRow("color: hsl(120 30% / .5)")]
+        [DataRow("background-color: color(profoto-rgb 0.4835 0.9167 0.2188)")]
+        public void HtmlMatches_Should_Not_Match(string htmlString)
+        {
+            MatchCollection matches = ColorUtils.MatchesColor(htmlString);
+
+            Assert.AreEqual(0, matches.Count);
         }
 
         [TestMethod]

--- a/test/EditorColorPreview.Test/HtmlMatchTests.cs
+++ b/test/EditorColorPreview.Test/HtmlMatchTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EditorColorPreview.Test
+{
+    [TestClass]
+    public class HtmlMatchTests
+    {
+        [DataTestMethod]
+        [DataRow("color: rgb(0, 0, 0)")]
+        [DataRow("color: hsl(120 30% 50%)")]
+        [DataRow("color: hsl(120 30% 50% / 0.5)")]
+        [DataRow("color: hsl(none none none)")]
+        [DataRow("color: hsl(0 0% 0%)")]
+        [DataRow("$sass-color: hsl(0 0% 0%)")]
+        public void HtmlMatches_Should_Match(string htmlString)
+        {
+            MatchCollection matches = ColorUtils.MatchesColor(htmlString);
+
+            Assert.AreEqual(1, matches.Count);
+        }
+
+        [TestMethod]
+        public void Multiple_Single_Line_Should_Be_Two()
+        {
+            MatchCollection matches = ColorUtils.MatchesColor("$sass-color: hsl(0 0% 0%) color: hsl(0 0% 0%)");
+
+            Assert.AreEqual(2, matches.Count);
+        }
+    }
+}

--- a/test/EditorColorPreview.Test/Properties/AssemblyInfo.cs
+++ b/test/EditorColorPreview.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("EditorColorPreview.Test")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("EditorColorPreview.Test")]
+[assembly: AssemblyCopyright("Copyright ©  2022")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("198e2552-b2b2-437e-8a9b-16ca9dfdc372")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/EditorColorPreview.Test/packages.config
+++ b/test/EditorColorPreview.Test/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="MSTest.TestAdapter" version="2.2.10" targetFramework="net48" />
-  <package id="MSTest.TestFramework" version="2.2.10" targetFramework="net48" />
-</packages>

--- a/test/EditorColorPreview.Test/packages.config
+++ b/test/EditorColorPreview.Test/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="2.2.7" targetFramework="net472" />
+  <package id="MSTest.TestFramework" version="2.2.7" targetFramework="net472" />
+</packages>

--- a/test/EditorColorPreview.Test/packages.config
+++ b/test/EditorColorPreview.Test/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MSTest.TestAdapter" version="2.2.7" targetFramework="net472" />
-  <package id="MSTest.TestFramework" version="2.2.7" targetFramework="net472" />
+  <package id="MSTest.TestAdapter" version="2.2.10" targetFramework="net48" />
+  <package id="MSTest.TestFramework" version="2.2.10" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
What started out as adding supporting for `hsl(200deg 75% 5%)` turned into a project to support all of CSS Color Module Level 4.

Add support for serializing spaces, comas, %, deg, slash, and none. Add support for resolving all sRGB functions `rgb()`, `rgba()`, `hsl()`, `hsla()`, `hwb()`. Add resolving support for none sRGB functions `lab()`, `lch()`, `oklab()`, and `oklch()`. Add support for resolving color spaces using the color function `color()`. There is one caveats, not with the code, but with supporting color spaces with large gamut than the sRGB color space. Without support for different color spaces and large gamut the colors are converted to sRGB. Some colors might not convert properly. Knowing these are edge cases I added them anyways. For future proofing, when Windows, Visual Studio, web browsers, and the hardware is there to support them and people buy the hardware. At that time the code can be changed 😀.

I added unit testing to help support the various color functions and the regex matching logic. I'm no regex expert, but I think I have that nailed down.

Here is an example in a SASS file

![image](https://user-images.githubusercontent.com/10999532/168884527-9467fef7-803b-4d02-aa4b-f5824a7133b1.png)

