### PR TITLE
Update ColorAdornmentTagger.cs

### DIFF
--- a/src/Adornments/ColorAdornmentTagger.cs
+++ b/src/Adornments/ColorAdornmentTagger.cs
@@ -19,7 +19,7 @@ namespace EditorColorPreview
         public ITagger<T> CreateTagger<T>(ITextView textView, ITextBuffer buffer) where T : ITag
         {
             // Abort if the file is too big
-            if (buffer.CurrentSnapshot.Length < 10000)
+            if (buffer.CurrentSnapshot.Length < 150000)
             {
                 return buffer.Properties.GetOrCreateSingletonProperty(() => new ColorAdornmentTagger(buffer, textView)) as ITagger<T>;
             }


### PR DESCRIPTION
increased the cutoff to 150,000 characters from 10,000 this is still way under the bootstrap.min.css file size (160,000+) so it won't freeze up VS when opening that file.

this would still be better as a VS setting, but for now keeps me working.